### PR TITLE
Build runner asset generation

### DIFF
--- a/flutter-init.sh
+++ b/flutter-init.sh
@@ -15,15 +15,18 @@ flutter pub get
 flutter pub global activate intl_utils
 flutter --no-color pub global run intl_utils:generate
 
+flutter pub global activate build_runner
+flutter pub run build_runner build --delete-conflicting-outputs
+
 flutter pub run flutter_oss_licenses:generate.dart
 mv lib/oss_licenses.dart lib/generated
 
-mkdir -p $GEN_FILE_PATH || true
+mkdir -p "$GEN_FILE_PATH" || true
 
-echo "const Map<String, String> flutterVersion =" > $FLUTTER_VERSION_FILE
-flutter --version --machine >> $FLUTTER_VERSION_FILE
-echo ";" >> $FLUTTER_VERSION_FILE
+echo "const Map<String, String> flutterVersion =" >"$FLUTTER_VERSION_FILE"
+flutter --version --machine >>"$FLUTTER_VERSION_FILE"
+echo ";" >>"$FLUTTER_VERSION_FILE"
 
-mkdir -p $ENV_FILE_PATH || true
-touch $ENV_FILE
-export > $ENV_FILE
+mkdir -p "$ENV_FILE_PATH" || true
+touch "$ENV_FILE"
+export >"$ENV_FILE"

--- a/src/ui/flutter_app/lib/services/audios.dart
+++ b/src/ui/flutter_app/lib/services/audios.dart
@@ -20,6 +20,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:sanmill/generated/assets/assets.gen.dart';
 import 'package:sanmill/shared/common/config.dart';
 import 'package:soundpool/soundpool.dart';
 import 'package:stack_trace/stack_trace.dart';
@@ -62,43 +63,43 @@ class Audios {
     }
 
     _drawSoundId = await _soundpool.load(
-      await rootBundle.load("assets/audios/draw.mp3"),
+      await rootBundle.load(Assets.audios.draw),
     );
 
     _flySoundId = await _soundpool.load(
-      await rootBundle.load("assets/audios/fly.mp3"),
+      await rootBundle.load(Assets.audios.fly),
     );
 
     _goSoundId = await _soundpool.load(
-      await rootBundle.load("assets/audios/go.mp3"),
+      await rootBundle.load(Assets.audios.go),
     );
 
     _illegalSoundId = await _soundpool.load(
-      await rootBundle.load("assets/audios/illegal.mp3"),
+      await rootBundle.load(Assets.audios.illegal),
     );
 
     _loseSoundId = await _soundpool.load(
-      await rootBundle.load("assets/audios/lose.mp3"),
+      await rootBundle.load(Assets.audios.lose),
     );
 
     _millSoundId = await _soundpool.load(
-      await rootBundle.load("assets/audios/mill.mp3"),
+      await rootBundle.load(Assets.audios.mill),
     );
 
     _placeSoundId = await _soundpool.load(
-      await rootBundle.load("assets/audios/place.mp3"),
+      await rootBundle.load(Assets.audios.place),
     );
 
     _removeSoundId = await _soundpool.load(
-      await rootBundle.load("assets/audios/remove.mp3"),
+      await rootBundle.load(Assets.audios.remove),
     );
 
     _selectSoundId = await _soundpool.load(
-      await rootBundle.load("assets/audios/select.mp3"),
+      await rootBundle.load(Assets.audios.select),
     );
 
     _winSoundId = await _soundpool.load(
-      await rootBundle.load("assets/audios/win.mp3"),
+      await rootBundle.load(Assets.audios.win),
     );
 
     _initialized = true;

--- a/src/ui/flutter_app/lib/shared/common/constants.dart
+++ b/src/ui/flutter_app/lib/shared/common/constants.dart
@@ -17,6 +17,7 @@
 */
 
 import 'dart:ui';
+import 'package:sanmill/generated/assets/assets.gen.dart';
 
 class Constants {
   const Constants._();
@@ -29,8 +30,8 @@ class Constants {
   static String settingsFilename = "${projectNameLower}_settings.json";
   static String crashLogsFileName = "$projectName-crash-logs.txt";
   static String environmentVariablesFilename =
-      "assets/files/environment_variables.txt";
-  static String gplLicenseFilename = "assets/licenses/GPL-3.0.txt";
+      Assets.files.environmentVariables;
+  static String gplLicenseFilename = Assets.licenses.gpl30;
 
   static String defaultLanguageCodeName = "Default";
 

--- a/src/ui/flutter_app/pubspec.yaml
+++ b/src/ui/flutter_app/pubspec.yaml
@@ -36,11 +36,17 @@ dependencies:
   #screen_recorder: ^0.0.2
 
 dev_dependencies:
+  build_runner: ^2.1.4
+  flutter_gen_runner: ^4.0.0
+
   flutter_oss_licenses: ^1.0.1
   flutter_test:
     sdk: flutter
   lint: ^1.7.2
   msix: ^2.1.3
+
+flutter_gen:
+  output: lib/generated/assets/
 
 flutter:
   generate: true


### PR DESCRIPTION
implements assets generation eliminating the possibility of wrong resource locations. #303 

You could cherrypick the commit as it is ready to be merged. It's just based on #284 rn.

We should also document the use of buildrunner or implement it in `flutter-init.sh`for now (althought the goal is to eventually migrate everything to buildrunner and away from the custom script)