### PR TITLE
android: Support compiling to Android 12

### DIFF
--- a/src/ui/flutter_app/android/app/build.gradle
+++ b/src/ui/flutter_app/android/app/build.gradle
@@ -40,7 +40,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     lintOptions {
         disable 'InvalidPackage'
@@ -49,7 +49,7 @@ android {
     defaultConfig {
         applicationId "com.calcitem.sanmill"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         ndk{

--- a/src/ui/flutter_app/android/app/build.gradle_fdroid
+++ b/src/ui/flutter_app/android/app/build.gradle_fdroid
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     lintOptions {
         disable 'InvalidPackage'
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "com.calcitem.sanmill"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         ndk{

--- a/src/ui/flutter_app/android/app/src/main/AndroidManifest.xml
+++ b/src/ui/flutter_app/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"


### PR DESCRIPTION
* Change compileSdkVersion and targetSdkVersion to 31.
* Declare on the Manifest with exported:true for MainActivity.

Reference:
https://medium.com/androiddevelopers/lets-be-explicit-about-our-intent-filters-c5dbe2dbdce0
https://cafonsomota.medium.com/android-12-dont-forget-to-set-android-exported-on-your-activities-services-and-receivers-3bee33f37beb
https://developer.android.com/guide/topics/manifest/activity-element#exported