### PR TITLE
flutter: windows: Disable Catcher (WAR)

### DIFF
--- a/src/ui/flutter_app/lib/main.dart
+++ b/src/ui/flutter_app/lib/main.dart
@@ -51,7 +51,7 @@ Future<void> main() async {
 
   _initUI();
 
-  if (EnvironmentConfig.catcher) {
+  if (EnvironmentConfig.catcher && !Platform.isWindows) {
     final catcher = Catcher(
       rootWidget: const SanmillApp(),
       ensureInitialized: true,


### PR DESCRIPTION
Issue: Throw UnimplementedError('windowsInfo() has not been implemented.')
when launching app.

Workaround solution: Disable Catcher for the Windows platform.

Reference: a96268d7200a48859d580be88af0813004a12a7e

Stack:
```
DeviceInfoPlatform.windowsInfo (device_info_plus_platform_interface.dart:87)
DeviceInfoPlugin.windowsInfo (device_info_plus.dart:78)
Catcher._loadDeviceInfo (catcher.dart:256)
Catcher._configure (catcher.dart:87)
new Catcher (catcher.dart:75)
main (main.dart:55)
```