### PR TITLE
fix directionality fixes #406

### DIFF
--- a/src/ui/flutter_app/lib/screens/game_page/board.dart
+++ b/src/ui/flutter_app/lib/screens/game_page/board.dart
@@ -234,9 +234,7 @@ class Board extends StatelessWidget {
       1
     ];
 
-    final bool ltr = Directionality.of(context) == TextDirection.ltr;
-
-    if (ltr) {
+    if (Directionality.of(context) == TextDirection.ltr) {
       for (final file in ['a', 'b', 'c', 'd', 'e', 'f', 'g']) {
         for (final rank in ['7', '6', '5', '4', '3', '2', '1']) {
           coordinates.add("$file$rank");

--- a/src/ui/flutter_app/lib/screens/game_page/game_page.dart
+++ b/src/ui/flutter_app/lib/screens/game_page/game_page.dart
@@ -71,7 +71,6 @@ class _GamePageState extends State<GamePage>
   late AnimationController _animationController;
   late Animation<double> animation;
   bool disposed = false;
-  late bool ltr;
   late double boardWidth;
 
   static const String _tag = "[game_page]";
@@ -1237,15 +1236,18 @@ class _GamePageState extends State<GamePage>
       EngineType.testViaLAN: FluentIcons.wifi_1_24_filled,
     };
 
-    final iconColor = LocalDatabaseService.colorSettings.messageColor;
-
-    final iconRow = Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Icon(engineTypeToIconLeft[widget.engineType], color: iconColor),
-        Icon(iconArrow, color: iconColor),
-        Icon(engineTypeToIconRight[widget.engineType], color: iconColor),
-      ],
+    final iconRow = IconTheme(
+      data: IconThemeData(
+        color: LocalDatabaseService.colorSettings.messageColor,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Icon(engineTypeToIconLeft[widget.engineType]),
+          Icon(iconArrow),
+          Icon(engineTypeToIconRight[widget.engineType]),
+        ],
+      ),
     );
 
     return Container(
@@ -1284,13 +1286,9 @@ class _GamePageState extends State<GamePage>
     if (gameInstance.position.phase == Phase.gameOver) {
       switch (gameInstance.position.winner) {
         case PieceColor.white:
-          return ltr
-              ? FluentIcons.toggle_left_24_regular
-              : FluentIcons.toggle_right_24_regular;
+          return FluentIcons.toggle_left_24_regular;
         case PieceColor.black:
-          return ltr
-              ? FluentIcons.toggle_right_24_regular
-              : FluentIcons.toggle_left_24_regular;
+          return FluentIcons.toggle_right_24_regular;
         default:
           return FluentIcons.handshake_24_regular;
       }
@@ -1456,9 +1454,7 @@ class _GamePageState extends State<GamePage>
   List<Widget> get historyNavToolbar {
     final takeBackAllButton = ToolbarItem(
       child: Icon(
-        ltr
-            ? FluentIcons.arrow_previous_24_regular
-            : FluentIcons.arrow_next_24_regular,
+        FluentIcons.arrow_previous_24_regular,
         semanticLabel: S.of(context).takeBackAll,
       ),
       onPressed: () => onTakeBackAllButtonPressed(false),
@@ -1466,9 +1462,7 @@ class _GamePageState extends State<GamePage>
 
     final takeBackButton = ToolbarItem(
       child: Icon(
-        ltr
-            ? FluentIcons.chevron_left_24_regular
-            : FluentIcons.chevron_right_24_regular,
+        FluentIcons.chevron_left_24_regular,
         semanticLabel: S.of(context).takeBack,
       ),
       onPressed: () async => onTakeBackButtonPressed(false),
@@ -1476,9 +1470,7 @@ class _GamePageState extends State<GamePage>
 
     final stepForwardButton = ToolbarItem(
       child: Icon(
-        ltr
-            ? FluentIcons.chevron_right_24_regular
-            : FluentIcons.chevron_left_24_regular,
+        FluentIcons.chevron_right_24_regular,
         semanticLabel: S.of(context).stepForward,
       ),
       onPressed: () async => onStepForwardButtonPressed(false),
@@ -1486,9 +1478,7 @@ class _GamePageState extends State<GamePage>
 
     final stepForwardAllButton = ToolbarItem(
       child: Icon(
-        ltr
-            ? FluentIcons.arrow_next_24_regular
-            : FluentIcons.arrow_previous_24_regular,
+        FluentIcons.arrow_next_24_regular,
         semanticLabel: S.of(context).stepForwardAll,
       ),
       onPressed: () async => onStepForwardAllButtonPressed(false),
@@ -1531,7 +1521,6 @@ class _GamePageState extends State<GamePage>
   void didChangeDependencies() {
     super.didChangeDependencies();
     screenPaddingH = _screenPaddingH;
-    ltr = Directionality.of(context) == TextDirection.ltr;
     _tip = S.of(context).welcome;
   }
 

--- a/src/ui/flutter_app/lib/shared/custom_drawer/src/widget.dart
+++ b/src/ui/flutter_app/lib/shared/custom_drawer/src/widget.dart
@@ -235,14 +235,14 @@ class _CustomDrawerState extends State<CustomDrawer>
     if (!_captured) return;
 
     final screenSize = MediaQuery.of(context).size;
-    final rtl = Directionality.of(context) == TextDirection.rtl;
+    final ltr = Directionality.of(context) == TextDirection.ltr;
 
     _freshPosition = details.globalPosition;
 
     final diff = (_freshPosition - _startPosition).dx;
 
     _animationController.value = _offsetValue +
-        (diff / (screenSize.width * _openRatio)) * (rtl ? -1 : 1);
+        (diff / (screenSize.width * _openRatio)) * (ltr ? 1 : -1);
   }
 
   void _handleDragEnd(DragEndDetails details) {

--- a/src/ui/flutter_app/lib/shared/settings/settings_list_tile.dart
+++ b/src/ui/flutter_app/lib/shared/settings/settings_list_tile.dart
@@ -38,8 +38,6 @@ class SettingsListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool ltr = Directionality.of(context) == TextDirection.ltr;
-
     return ListTile(
       title: Text(
         titleString,
@@ -56,12 +54,13 @@ class SettingsListTile extends StatelessWidget {
             trailingColor?.value.toRadixString(16) ?? trailingString ?? '',
             style: TextStyle(backgroundColor: trailingColor),
           ),
-          Icon(
-            ltr
-                ? FluentIcons.chevron_right_24_regular
-                : FluentIcons.chevron_left_24_regular,
-            color: AppTheme.listTileSubtitleColor,
-          )
+          const Directionality(
+            textDirection: TextDirection.ltr,
+            child: Icon(
+              FluentIcons.chevron_right_24_regular,
+              color: AppTheme.listTileSubtitleColor,
+            ),
+          ),
         ],
       ),
       onTap: onTap,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fixes and cleans up how we handle single direction icons (now handling them propperly :upside_down_face:).
The nav_toolbar has been fixed and verified.
Please thoroughly test the directionality of the other icons (mainly the AppBar tooltip thingy). Thing like when winning is the arrow for the winner the correct way? ...

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
