### PR TITLE
Fix setSpecialCountryAndRegion() doesn't work

### DIFF
--- a/src/ui/flutter_app/lib/services/language_info.dart
+++ b/src/ui/flutter_app/lib/services/language_info.dart
@@ -115,8 +115,8 @@ String specialCountryAndRegion = "";
 void setSpecialCountryAndRegion(BuildContext context) {
   final Locale currentLocale = Localizations.localeOf(context);
 
-  switch (currentLocale.countryCode) {
-    case "IR":
+  switch (currentLocale.toString()) {
+    case "fa":
       specialCountryAndRegion = "Iran";
       break;
     default:


### PR DESCRIPTION
Problem Description:
1. Set system language to Farsi.
2. Restore to default settings.
3. The default configuration loaded is not Twelve Men's Morris.

The commit that caused the problem:
  399250df9d2d1a56b08844fc9778f97b3c63687f
