### PR TITLE
flutter_app: Add .run to .gitignore

### DIFF
--- a/src/ui/flutter_app/.gitignore
+++ b/src/ui/flutter_app/.gitignore
@@ -44,3 +44,4 @@ lib/generated_plugin_registrant.dart
 
 # Sanmill Settings
 sanmill_settings.json
+.run/


### PR DESCRIPTION
Because we often need to copy .run in the root directory to flutter_app directory to load configurations in .run with IDE when we only need to open the Flutter folder.
