### PR TITLE
l10n: Replace move_number(0) with move at move option

### DIFF
--- a/src/ui/flutter_app/lib/screens/game_page/game_page.dart
+++ b/src/ui/flutter_app/lib/screens/game_page/game_page.dart
@@ -225,7 +225,7 @@ class _GamePageState extends State<GamePage>
         context: context,
         backgroundColor: Colors.transparent,
         builder: (context) => SimpleDialog(
-          semanticLabel: S.of(context).move_number(0),
+          semanticLabel: S.of(context).move,
           backgroundColor: Colors.transparent,
           children: <Widget>[
             if (!LocalDatabaseService
@@ -482,7 +482,7 @@ class _GamePageState extends State<GamePage>
     final moveButton = ToolbarItem.icon(
       onPressed: _showMoveOptions,
       icon: const Icon(FluentIcons.calendar_agenda_24_regular),
-      label: Text(S.of(context).move_number(0)),
+      label: Text(S.of(context).move),
     );
 
     final infoButton = ToolbarItem.icon(

--- a/src/ui/flutter_app/lib/shared/number_picker.dart
+++ b/src/ui/flutter_app/lib/shared/number_picker.dart
@@ -38,7 +38,7 @@ class NumberPicker extends StatelessWidget {
 
     final List<Widget> _items = List.generate(
       end,
-      (index) => Text(S.of(context).move_number(start + index)),
+      (index) => Text(S.of(context).moveNumber(start + index)),
     );
 
     return AlertDialog(


### PR DESCRIPTION
Keep only move_number (renamed to moveNumber) in NumberPicker.

This is because in some languages (e.g. Chinese), the moveNumber
used in NumberPicker and Move option is not the same word.

Therefore we separate the string resources in these two places
into different resources.