### PR TITLE
Change the wrongly colorSettingsKey to the correct displaySettingsKey

### DIFF
--- a/src/ui/flutter_app/lib/screens/appearance_settings/animation_duration_slider.dart
+++ b/src/ui/flutter_app/lib/screens/appearance_settings/animation_duration_slider.dart
@@ -27,7 +27,7 @@ class _AnimationDurationSlider extends StatelessWidget {
         valueListenable: DB().listenDisplaySettings,
         builder: (context, Box<DisplaySettings> box, _) {
           final DisplaySettings _displaySettings = box.get(
-            DB.colorSettingsKey,
+            DB.displaySettingsKey,
             defaultValue: const DisplaySettings(),
           )!;
 

--- a/src/ui/flutter_app/lib/screens/appearance_settings/appearance_settings_page.dart
+++ b/src/ui/flutter_app/lib/screens/appearance_settings/appearance_settings_page.dart
@@ -216,7 +216,7 @@ class AppearanceSettingsPage extends StatelessWidget {
     _,
   ) {
     final DisplaySettings _displaySettings = box.get(
-      DB.colorSettingsKey,
+      DB.displaySettingsKey,
       defaultValue: const DisplaySettings(),
     )!;
     return SettingsCard(

--- a/src/ui/flutter_app/lib/screens/appearance_settings/board_boarder_line_width_slider.dart
+++ b/src/ui/flutter_app/lib/screens/appearance_settings/board_boarder_line_width_slider.dart
@@ -27,7 +27,7 @@ class _BoardBorderWidthSlider extends StatelessWidget {
         valueListenable: DB().listenDisplaySettings,
         builder: (context, Box<DisplaySettings> box, _) {
           final DisplaySettings _displaySettings = box.get(
-            DB.colorSettingsKey,
+            DB.displaySettingsKey,
             defaultValue: const DisplaySettings(),
           )!;
 

--- a/src/ui/flutter_app/lib/screens/appearance_settings/board_inner_line_width_slider.dart
+++ b/src/ui/flutter_app/lib/screens/appearance_settings/board_inner_line_width_slider.dart
@@ -27,7 +27,7 @@ class _BoardInnerWidthSlider extends StatelessWidget {
         valueListenable: DB().listenDisplaySettings,
         builder: (context, Box<DisplaySettings> box, _) {
           final DisplaySettings _displaySettings = box.get(
-            DB.colorSettingsKey,
+            DB.displaySettingsKey,
             defaultValue: const DisplaySettings(),
           )!;
 

--- a/src/ui/flutter_app/lib/screens/appearance_settings/board_top_slider.dart
+++ b/src/ui/flutter_app/lib/screens/appearance_settings/board_top_slider.dart
@@ -27,7 +27,7 @@ class _BoardTopSlider extends StatelessWidget {
         valueListenable: DB().listenDisplaySettings,
         builder: (context, Box<DisplaySettings> box, _) {
           final DisplaySettings _displaySettings = box.get(
-            DB.colorSettingsKey,
+            DB.displaySettingsKey,
             defaultValue: const DisplaySettings(),
           )!;
 
@@ -37,7 +37,7 @@ class _BoardTopSlider extends StatelessWidget {
             divisions: 288,
             label: _displaySettings.boardTop.toStringAsFixed(1),
             onChanged: (value) {
-              logger.v("[config] AnimationDuration value: $value");
+              logger.v("[config] boardTop value: $value");
               DB().displaySettings = _displaySettings.copyWith(boardTop: value);
             },
           );

--- a/src/ui/flutter_app/lib/screens/appearance_settings/font_size_slider.dart
+++ b/src/ui/flutter_app/lib/screens/appearance_settings/font_size_slider.dart
@@ -27,7 +27,7 @@ class _FontSizeSlider extends StatelessWidget {
         valueListenable: DB().listenDisplaySettings,
         builder: (context, Box<DisplaySettings> box, _) {
           final DisplaySettings _displaySettings = box.get(
-            DB.colorSettingsKey,
+            DB.displaySettingsKey,
             defaultValue: const DisplaySettings(),
           )!;
 

--- a/src/ui/flutter_app/lib/screens/appearance_settings/piece_width_slider.dart
+++ b/src/ui/flutter_app/lib/screens/appearance_settings/piece_width_slider.dart
@@ -27,7 +27,7 @@ class _PieceWidthSlider extends StatelessWidget {
         valueListenable: DB().listenDisplaySettings,
         builder: (context, Box<DisplaySettings> box, _) {
           final DisplaySettings _displaySettings = box.get(
-            DB.colorSettingsKey,
+            DB.displaySettingsKey,
             defaultValue: const DisplaySettings(),
           )!;
 

--- a/src/ui/flutter_app/lib/screens/appearance_settings/point_width_slider.dart
+++ b/src/ui/flutter_app/lib/screens/appearance_settings/point_width_slider.dart
@@ -29,7 +29,7 @@ class _PointWidthSlider extends StatelessWidget {
         valueListenable: DB().listenDisplaySettings,
         builder: (context, Box<DisplaySettings> box, _) {
           final DisplaySettings _displaySettings = box.get(
-            DB.colorSettingsKey,
+            DB.displaySettingsKey,
             defaultValue: const DisplaySettings(),
           )!;
 


### PR DESCRIPTION
Change the wrongly `colorSettingsKey` to the correct `displaySettingsKey`.
But now the values of displaySettingsKey and colorSettingsKey are both "settings",
there is no difference, so the modification does not affect the logic.

**I'm still not sure if it's reasonable for both to be the same?**