### PR TITLE
about: Change about page's title from 'About Mill' to 'About'

### DIFF
--- a/src/ui/flutter_app/lib/screens/about_page.dart
+++ b/src/ui/flutter_app/lib/screens/about_page.dart
@@ -125,7 +125,7 @@ class AboutPage extends StatelessWidget {
       backgroundColor: AppTheme.aboutPageBackgroundColor,
       appBar: AppBar(
         leading: DrawerIcon.of(context)?.icon,
-        title: Text("${S.of(context).about} ${S.of(context).appName}"),
+        title: Text(S.of(context).about),
       ),
       body: ListView.separated(
         itemBuilder: (_, index) => _children[index],


### PR DESCRIPTION
@freeingi said:
this word 'About' will place behind of 'Mill'. (Like a 'Mill 에 대해서') That will be not only problem of korean, so I think we need to translate not 'About' to all 'About Mill'

The current processing method is to directly remove 'Mill' from the title, and only keep 'About'. Translators can decide whether to translate about as 'About' or 'About Mill' according to their own language length and expression habits.

See:
https://hosted.weblate.org/translate/sanmill/flutter/en/?checksum=92959093571d1319