### PR TITLE
tip: Fix tip always show 'waiting' when taking back

### DIFF
--- a/src/ui/flutter_app/lib/services/mill/src/controller.dart
+++ b/src/ui/flutter_app/lib/services/mill/src/controller.dart
@@ -32,7 +32,7 @@ class MillController {
   late _Game gameInstance;
   late Position position;
   late Engine engine;
-  late HeaderTipState tip;
+  final HeaderTipState tip = HeaderTipState();
   late _GameRecorder recorder;
 
   bool _initialized = false;
@@ -98,7 +98,6 @@ class MillController {
     gameInstance = _Game();
     engine = Engine();
     recorder = _GameRecorder();
-    tip = HeaderTipState();
 
     _startGame();
   }


### PR DESCRIPTION
notifyListeners() in HeaderTipState.showTip() sometime doesn't work.
No listeners, I don't know why.

Change
  late HeaderTipState tip
to
  final HeaderTipState tip = HeaderTipState();
can solve it.