### PR TITLE
 Fix AI's move is the same as human's occasionally (must appear on Windows)

### DIFF
--- a/src/ui/flutter_app/lib/services/mill/src/position.dart
+++ b/src/ui/flutter_app/lib/services/mill/src/position.dart
@@ -769,6 +769,10 @@ class Position {
     }
 
     while (iterator.moveNext()) {
+      if (iterator.prev != null) {
+        assert(iterator.current!.move != iterator.prev!.move);
+      }
+
       buffer.writeSpace(iterator.current!.move);
     }
 

--- a/src/ui/flutter_app/lib/services/mill/src/tap_handler.dart
+++ b/src/ui/flutter_app/lib/services/mill/src/tap_handler.dart
@@ -250,8 +250,9 @@ class TapHandler {
         logger.v("$_tag Searching..., isMoveNow: $isMoveNow");
         final extMove = await controller.engine.search(moveNow: isMoveNow);
 
-        await controller.gameInstance.doMove(extMove);
-        controller.recorder.add(position._record!);
+        if (await controller.gameInstance.doMove(extMove)) {
+          controller.recorder.add(extMove);
+        }
         animationController.reset();
         animationController.animateTo(1.0);
 

--- a/src/ui/flutter_app/lib/shared/iterable/pointed_list.dart
+++ b/src/ui/flutter_app/lib/shared/iterable/pointed_list.dart
@@ -179,6 +179,13 @@ class PointedListIterator<E> extends BidirectionalIterator<E?> {
     return null;
   }
 
+  E? get prev {
+    if (_index != null && index != 0 && _parent[_index! - 1] != null) {
+      return _parent[_index! - 1];
+    }
+    return null;
+  }
+
   @override
   bool operator ==(Object other) =>
       other is PointedListIterator &&


### PR DESCRIPTION
Steps to reproduce:
piece count = 9
Diagonal line = on

Import

     1.    b2    b4
     2.    f2    d2
     3.    g1    f4
     4.    a1    d6
     5.    c3xd2    d2
     6.    e3xb4    b4
     7.    b6    e5

Tap c5.
AI still do move c5.

Strangely, it can only be reproduced on Windows, but not on Android. The reason is not clear.

This is the perfection of commit 6f6115d6a2cbb699c01d0191b87898c6c813b290.
