### PR TITLE
Fix flutter ui

### DIFF
--- a/src/ui/flutter_app/lib/screens/game_page/game_page.dart
+++ b/src/ui/flutter_app/lib/screens/game_page/game_page.dart
@@ -159,28 +159,41 @@ class _GameState extends State<_Game> {
   // Icons: https://github.com/microsoft/fluentui-system-icons/blob/main/icons_regular.md
 
   List<Widget> mainToolbarItems(BuildContext context) {
+    final itemMaxWidth = (MediaQuery.of(context).size.width - AppTheme.boardMargin * 2) / 4 - 16;
     final gameButton = ToolbarItem.icon(
       onPressed: () => _showGameModalBottomSheet(context),
       icon: const Icon(FluentIcons.table_simple_24_regular),
-      label: Text(S.of(context).game),
+      label: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: itemMaxWidth),
+          child: Text(S.of(context).game, maxLines: 1, overflow: TextOverflow.ellipsis),
+      ),
     );
 
     final optionsButton = ToolbarItem.icon(
       onPressed: () => _showGeneralSettings(context),
       icon: const Icon(FluentIcons.settings_24_regular),
-      label: Text(S.of(context).options),
+      label: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: itemMaxWidth),
+          child: Text(S.of(context).options, maxLines: 1, overflow: TextOverflow.ellipsis),
+      ),
     );
 
     final moveButton = ToolbarItem.icon(
       onPressed: () => _showMoveModalBottomSheet(context),
       icon: const Icon(FluentIcons.calendar_agenda_24_regular),
-      label: Text(S.of(context).move),
+      label: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: itemMaxWidth),
+          child: Text(S.of(context).move, maxLines: 1, overflow: TextOverflow.ellipsis),
+      ),
     );
 
     final infoButton = ToolbarItem.icon(
       onPressed: () => _showInfoDialog(context),
       icon: const Icon(FluentIcons.book_information_24_regular),
-      label: Text(S.of(context).info),
+      label: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: itemMaxWidth),
+          child: Text(S.of(context).info, maxLines: 1, overflow: TextOverflow.ellipsis),
+      ),
     );
 
     return <Widget>[

--- a/src/ui/flutter_app/lib/screens/game_page/game_page.dart
+++ b/src/ui/flutter_app/lib/screens/game_page/game_page.dart
@@ -98,7 +98,7 @@ class GamePage extends StatelessWidget {
 
                 return ConstrainedBox(
                   constraints: constraint,
-                  child: const SingleChildScrollView(child: _Game()),
+                  child: const _Game(),
                 );
               },
             ),
@@ -264,107 +264,120 @@ class _GameState extends State<_Game> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: <Widget>[
-        GameHeader(),
-        (DB().displaySettings.isUnplacedAndRemovedPiecesShown ||
-                    MillController().gameInstance.gameMode ==
-                        GameMode.setupPosition) &&
-                !(Constants.isSmallScreen == true &&
-                    DB().ruleSettings.piecesCount > 9)
-            ? Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: <Widget>[
-                    Text(
-                        getPiecesText(
-                            MillController().position.pieceInHandCount[
-                                !DB().generalSettings.aiMovesFirst
-                                    ? PieceColor.black
-                                    : PieceColor.white]!),
-                        style: TextStyle(
-                            color: !DB().generalSettings.aiMovesFirst
-                                ? DB().colorSettings.blackPieceColor
-                                : DB().colorSettings.whitePieceColor)),
-                    Text(
-                        getPiecesText(DB().ruleSettings.piecesCount -
-                            MillController().position.pieceInHandCount[
-                                !DB().generalSettings.aiMovesFirst
-                                    ? PieceColor.white
-                                    : PieceColor.black]! -
-                            MillController().position.pieceOnBoardCount[
-                                !DB().generalSettings.aiMovesFirst
-                                    ? PieceColor.white
-                                    : PieceColor.black]!),
-                        style: TextStyle(
-                            color: !DB().generalSettings.aiMovesFirst
-                                ? DB()
-                                    .colorSettings
-                                    .whitePieceColor
-                                    .withOpacity(0.8)
-                                : DB()
-                                    .colorSettings
-                                    .blackPieceColor
-                                    .withOpacity(0.8)))
-                  ])
-            : const SizedBox(height: AppTheme.boardMargin),
-        const Board(),
-        (DB().displaySettings.isUnplacedAndRemovedPiecesShown ||
-                    MillController().gameInstance.gameMode ==
-                        GameMode.setupPosition) &&
-                !(Constants.isSmallScreen == true &&
-                    DB().ruleSettings.piecesCount > 9)
-            ? Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: <Widget>[
-                    Text(
-                        getPiecesText(DB().ruleSettings.piecesCount -
-                            MillController().position.pieceInHandCount[
-                                !DB().generalSettings.aiMovesFirst
-                                    ? PieceColor.black
-                                    : PieceColor.white]! -
-                            MillController().position.pieceOnBoardCount[
-                                !DB().generalSettings.aiMovesFirst
-                                    ? PieceColor.black
-                                    : PieceColor.white]!),
-                        style: TextStyle(
-                            color: !DB().generalSettings.aiMovesFirst
-                                ? DB()
-                                    .colorSettings
-                                    .blackPieceColor
-                                    .withOpacity(0.8)
-                                : DB()
-                                    .colorSettings
-                                    .whitePieceColor
-                                    .withOpacity(0.8))),
-                    Text(
-                        getPiecesText(
-                            MillController().position.pieceInHandCount[
-                                !DB().generalSettings.aiMovesFirst
-                                    ? PieceColor.white
-                                    : PieceColor.black]!),
-                        style: TextStyle(
-                            color: DB().generalSettings.aiMovesFirst
-                                ? DB().colorSettings.blackPieceColor
-                                : DB().colorSettings.whitePieceColor))
-                  ])
-            : const SizedBox(height: AppTheme.boardMargin),
-        if (MillController().gameInstance.gameMode == GameMode.setupPosition)
-          const SetupPositionToolBar(),
-        if (DB().displaySettings.isHistoryNavigationToolbarShown &&
-            MillController().gameInstance.gameMode != GameMode.setupPosition)
-          GamePageToolBar(
-            backgroundColor:
-                DB().colorSettings.navigationToolbarBackgroundColor,
-            itemColor: DB().colorSettings.navigationToolbarIconColor,
-            children: historyNavToolbarItems(context),
+    return SafeArea(
+      bottom: false,
+      child: Stack(
+        children: [
+          SingleChildScrollView(
+            child: Column(
+              children: <Widget>[
+                GameHeader(),
+                (DB().displaySettings.isUnplacedAndRemovedPiecesShown ||
+                            MillController().gameInstance.gameMode ==
+                                GameMode.setupPosition) &&
+                        !(Constants.isSmallScreen == true &&
+                            DB().ruleSettings.piecesCount > 9)
+                    ? Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                            Text(
+                                getPiecesText(
+                                    MillController().position.pieceInHandCount[
+                                        !DB().generalSettings.aiMovesFirst
+                                            ? PieceColor.black
+                                            : PieceColor.white]!),
+                                style: TextStyle(
+                                    color: !DB().generalSettings.aiMovesFirst
+                                        ? DB().colorSettings.blackPieceColor
+                                        : DB().colorSettings.whitePieceColor)),
+                            Text(
+                                getPiecesText(DB().ruleSettings.piecesCount -
+                                    MillController().position.pieceInHandCount[
+                                        !DB().generalSettings.aiMovesFirst
+                                            ? PieceColor.white
+                                            : PieceColor.black]! -
+                                    MillController().position.pieceOnBoardCount[
+                                        !DB().generalSettings.aiMovesFirst
+                                            ? PieceColor.white
+                                            : PieceColor.black]!),
+                                style: TextStyle(
+                                    color: !DB().generalSettings.aiMovesFirst
+                                        ? DB()
+                                            .colorSettings
+                                            .whitePieceColor
+                                            .withOpacity(0.8)
+                                        : DB()
+                                            .colorSettings
+                                            .blackPieceColor
+                                            .withOpacity(0.8)))
+                          ])
+                    : const SizedBox(height: AppTheme.boardMargin),
+                const Board(),
+                (DB().displaySettings.isUnplacedAndRemovedPiecesShown ||
+                            MillController().gameInstance.gameMode ==
+                                GameMode.setupPosition) &&
+                        !(Constants.isSmallScreen == true &&
+                            DB().ruleSettings.piecesCount > 9)
+                    ? Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                            Text(
+                                getPiecesText(DB().ruleSettings.piecesCount -
+                                    MillController().position.pieceInHandCount[
+                                        !DB().generalSettings.aiMovesFirst
+                                            ? PieceColor.black
+                                            : PieceColor.white]! -
+                                    MillController().position.pieceOnBoardCount[
+                                        !DB().generalSettings.aiMovesFirst
+                                            ? PieceColor.black
+                                            : PieceColor.white]!),
+                                style: TextStyle(
+                                    color: !DB().generalSettings.aiMovesFirst
+                                        ? DB()
+                                            .colorSettings
+                                            .blackPieceColor
+                                            .withOpacity(0.8)
+                                        : DB()
+                                            .colorSettings
+                                            .whitePieceColor
+                                            .withOpacity(0.8))),
+                            Text(
+                                getPiecesText(
+                                    MillController().position.pieceInHandCount[
+                                        !DB().generalSettings.aiMovesFirst
+                                            ? PieceColor.white
+                                            : PieceColor.black]!),
+                                style: TextStyle(
+                                    color: DB().generalSettings.aiMovesFirst
+                                        ? DB().colorSettings.blackPieceColor
+                                        : DB().colorSettings.whitePieceColor))
+                          ])
+                    : const SizedBox(height: AppTheme.boardMargin),
+                if (MillController().gameInstance.gameMode == GameMode.setupPosition)
+                  const SetupPositionToolBar(),
+                if (DB().displaySettings.isHistoryNavigationToolbarShown &&
+                    MillController().gameInstance.gameMode != GameMode.setupPosition)
+                  GamePageToolBar(
+                    backgroundColor:
+                        DB().colorSettings.navigationToolbarBackgroundColor,
+                    itemColor: DB().colorSettings.navigationToolbarIconColor,
+                    children: historyNavToolbarItems(context),
+                  ),
+                if (MillController().gameInstance.gameMode != GameMode.setupPosition)
+                  GamePageToolBar(
+                    backgroundColor: DB().colorSettings.mainToolbarBackgroundColor,
+                    itemColor: DB().colorSettings.mainToolbarIconColor,
+                    children: mainToolbarItems(context),
+                  ),
+              ],
+            ),
           ),
-        if (MillController().gameInstance.gameMode != GameMode.setupPosition)
-          GamePageToolBar(
-            backgroundColor: DB().colorSettings.mainToolbarBackgroundColor,
-            itemColor: DB().colorSettings.mainToolbarIconColor,
-            children: mainToolbarItems(context),
+          Align(
+            alignment: AlignmentDirectional.topStart,
+            child: DrawerIcon.of(context)?.icon,
           ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/src/ui/flutter_app/lib/screens/game_page/game_page.dart
+++ b/src/ui/flutter_app/lib/screens/game_page/game_page.dart
@@ -159,11 +159,17 @@ class _GameState extends State<_Game> {
   // Icons: https://github.com/microsoft/fluentui-system-icons/blob/main/icons_regular.md
 
   List<Widget> mainToolbarItems(BuildContext context) {
-    final itemMaxWidth = (MediaQuery.of(context).size.width - AppTheme.boardMargin * 2) / 4 - 16;
+    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
+      const EdgeInsets.all(8),
+      const EdgeInsets.symmetric(horizontal: 8),
+      const EdgeInsets.symmetric(horizontal: 4),
+      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+    );
+    final itemMaxWidth = (MediaQuery.of(context).size.width - AppTheme.boardMargin * 2) / 4 - scaledPadding.horizontal;
     final gameButton = ToolbarItem.icon(
       onPressed: () => _showGameModalBottomSheet(context),
       icon: const Icon(FluentIcons.table_simple_24_regular),
-      label: ConstrainedBox(
+      label: Container(
           constraints: BoxConstraints(maxWidth: itemMaxWidth),
           child: Text(S.of(context).game, maxLines: 1, overflow: TextOverflow.ellipsis),
       ),

--- a/src/ui/flutter_app/lib/screens/game_page/header.dart
+++ b/src/ui/flutter_app/lib/screens/game_page/header.dart
@@ -81,25 +81,17 @@ class _GameHeaderState extends State<GameHeader> {
     );
 
     final appBar = BlockSemantics(
-      child: Stack(
-        children: [
-          Align(
-            alignment: AlignmentDirectional.topStart,
-            child: DrawerIcon.of(context)?.icon,
+      child: Center(
+        child: Padding(
+          padding: EdgeInsets.only(top: DB().displaySettings.boardTop),
+          child: Column(
+            children: <Widget>[
+              const HeaderIcons(),
+              divider,
+              const HeaderTip(),
+            ],
           ),
-          Center(
-            child: Padding(
-              padding: EdgeInsets.only(top: DB().displaySettings.boardTop),
-              child: Column(
-                children: <Widget>[
-                  const HeaderIcons(),
-                  divider,
-                  const HeaderTip(),
-                ],
-              ),
-            ),
-          ),
-        ],
+        ),
       ),
     );
 

--- a/src/ui/flutter_app/lib/screens/general_settings/general_settings_page.dart
+++ b/src/ui/flutter_app/lib/screens/general_settings/general_settings_page.dart
@@ -45,7 +45,7 @@ class GeneralSettingsPage extends StatelessWidget {
         builder: (_) => const _ResetSettingsAlert(),
       );
 
-  void _setSkillLevel(BuildContext context) => showModalBottomSheet(
+  void _setSkillLevel(BuildContext context) => showDialog(
         context: context,
         builder: (_) => const _SkillLevelPicker(),
       );

--- a/src/ui/flutter_app/lib/screens/general_settings/general_settings_page.dart
+++ b/src/ui/flutter_app/lib/screens/general_settings/general_settings_page.dart
@@ -16,6 +16,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart' show Box;
 import 'package:sanmill/generated/intl/l10n.dart';
@@ -32,7 +33,7 @@ import 'package:sanmill/shared/theme/app_theme.dart';
 part 'package:sanmill/screens/general_settings/algorithm_modal.dart';
 part 'package:sanmill/screens/general_settings/move_time_slider.dart';
 part 'package:sanmill/screens/general_settings/reset_settings_alert.dart';
-part 'package:sanmill/screens/general_settings/skill_level_slider.dart';
+part 'package:sanmill/screens/general_settings/skill_level_picker.dart';
 
 class GeneralSettingsPage extends StatelessWidget {
   const GeneralSettingsPage({Key? key}) : super(key: key);
@@ -46,7 +47,7 @@ class GeneralSettingsPage extends StatelessWidget {
 
   void _setSkillLevel(BuildContext context) => showModalBottomSheet(
         context: context,
-        builder: (_) => const _SkillLevelSlider(),
+        builder: (_) => const _SkillLevelPicker(),
       );
 
   void _setMoveTime(BuildContext context) => showModalBottomSheet(

--- a/src/ui/flutter_app/lib/screens/general_settings/skill_level_picker.dart
+++ b/src/ui/flutter_app/lib/screens/general_settings/skill_level_picker.dart
@@ -43,52 +43,53 @@ class _SkillLevelPickerState extends State<_SkillLevelPicker> {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      label: S.of(context).skillLevel,
-      child: ValueListenableBuilder(
-        valueListenable: DB().listenGeneralSettings,
-        builder: (context, Box<GeneralSettings> box, _) {
-          final GeneralSettings generalSettings = box.get(
-            DB.generalSettingsKey,
-            defaultValue: const GeneralSettings(),
-          )!;
-
-          return Column(
-            children: [
-              Row(
-                children: [
-                  TextButton(
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                    },
-                    child: const Text('取消'),
-                  ),
-                  const Spacer(),
-                  TextButton(
-                    onPressed: () {
-                      DB().generalSettings =
-                          generalSettings.copyWith(skillLevel: _level);
-                      Navigator.of(context).pop();
-                    },
-                    child: const Text('确定'),
-                  )
-                ],
+    return ValueListenableBuilder(
+      valueListenable: DB().listenGeneralSettings,
+      builder: (context, Box<GeneralSettings> box, _) {
+        final GeneralSettings generalSettings = box.get(
+          DB.generalSettingsKey,
+          defaultValue: const GeneralSettings(),
+        )!;
+        return AlertDialog(
+          title: Text(
+            S.of(context).skillLevel,
+            style: AppTheme.dialogTitleTextStyle,
+            textScaleFactor: DB().displaySettings.fontScale,
+          ),
+          content: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 150),
+            child: CupertinoPicker(
+              scrollController: _controller,
+              itemExtent: 44,
+              children: List.generate(Constants.topSkillLevel,
+                  (level) => Center(child: Text('${level + 1}'))),
+              onSelectedItemChanged: (value) {
+                _level = value + 1;
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              child: Text(
+                S.of(context).cancel,
+                textScaleFactor: DB().displaySettings.fontScale,
               ),
-              Expanded(
-                child: CupertinoPicker(
-                  scrollController: _controller,
-                  itemExtent: 44,
-                  children: List.generate(Constants.topSkillLevel,
-                      (level) => Center(child: Text('${level + 1}'))),
-                  onSelectedItemChanged: (numb) {
-                    _level = numb + 1;
-                  },
-                ),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            TextButton(
+              child: Text(
+                S.of(context).confirm,
+                textScaleFactor: DB().displaySettings.fontScale,
               ),
-            ],
-          );
-        },
-      ),
+              onPressed: () {
+                DB().generalSettings =
+                    generalSettings.copyWith(skillLevel: _level);
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/src/ui/flutter_app/lib/screens/general_settings/skill_level_picker.dart
+++ b/src/ui/flutter_app/lib/screens/general_settings/skill_level_picker.dart
@@ -26,11 +26,13 @@ class _SkillLevelPicker extends StatefulWidget {
 class _SkillLevelPickerState extends State<_SkillLevelPicker> {
   late FixedExtentScrollController _controller;
 
+  late int _level;
+
   @override
   void initState() {
     super.initState();
-    _controller = FixedExtentScrollController(
-        initialItem: DB().generalSettings.skillLevel - 1);
+    _level = DB().generalSettings.skillLevel;
+    _controller = FixedExtentScrollController(initialItem: _level - 1);
   }
 
   @override
@@ -41,8 +43,6 @@ class _SkillLevelPickerState extends State<_SkillLevelPicker> {
 
   @override
   Widget build(BuildContext context) {
-    final size = Theme.of(context).textTheme.bodyText1!.fontSize!;
-
     return Semantics(
       label: S.of(context).skillLevel,
       child: ValueListenableBuilder(
@@ -53,15 +53,39 @@ class _SkillLevelPickerState extends State<_SkillLevelPicker> {
             defaultValue: const GeneralSettings(),
           )!;
 
-          return CupertinoPicker(
-            scrollController: _controller,
-            itemExtent: size + 12,
-            children: List.generate(
-                Constants.topSkillLevel, (index) => Text('${index + 1}')),
-            onSelectedItemChanged: (numb) {
-              DB().generalSettings =
-                  generalSettings.copyWith(skillLevel: numb + 1);
-            },
+          return Column(
+            children: [
+              Row(
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                    child: const Text('取消'),
+                  ),
+                  const Spacer(),
+                  TextButton(
+                    onPressed: () {
+                      DB().generalSettings =
+                          generalSettings.copyWith(skillLevel: _level);
+                      Navigator.of(context).pop();
+                    },
+                    child: const Text('确定'),
+                  )
+                ],
+              ),
+              Expanded(
+                child: CupertinoPicker(
+                  scrollController: _controller,
+                  itemExtent: 44,
+                  children: List.generate(Constants.topSkillLevel,
+                      (level) => Center(child: Text('${level + 1}'))),
+                  onSelectedItemChanged: (numb) {
+                    _level = numb + 1;
+                  },
+                ),
+              ),
+            ],
           );
         },
       ),

--- a/src/ui/flutter_app/lib/screens/general_settings/skill_level_picker.dart
+++ b/src/ui/flutter_app/lib/screens/general_settings/skill_level_picker.dart
@@ -16,11 +16,33 @@
 
 part of 'package:sanmill/screens/general_settings/general_settings_page.dart';
 
-class _SkillLevelSlider extends StatelessWidget {
-  const _SkillLevelSlider({Key? key}) : super(key: key);
+class _SkillLevelPicker extends StatefulWidget {
+  const _SkillLevelPicker({Key? key}) : super(key: key);
+
+  @override
+  State<_SkillLevelPicker> createState() => _SkillLevelPickerState();
+}
+
+class _SkillLevelPickerState extends State<_SkillLevelPicker> {
+  late FixedExtentScrollController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = FixedExtentScrollController(
+        initialItem: DB().generalSettings.skillLevel - 1);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
+    final size = Theme.of(context).textTheme.bodyText1!.fontSize!;
+
     return Semantics(
       label: S.of(context).skillLevel,
       child: ValueListenableBuilder(
@@ -31,16 +53,14 @@ class _SkillLevelSlider extends StatelessWidget {
             defaultValue: const GeneralSettings(),
           )!;
 
-          return Slider(
-            value: generalSettings.skillLevel.toDouble(),
-            min: 1,
-            max: Constants.topSkillLevel.toDouble(),
-            divisions: Constants.topSkillLevel - 1,
-            label: generalSettings.skillLevel.toString(),
-            onChanged: (value) {
+          return CupertinoPicker(
+            scrollController: _controller,
+            itemExtent: size + 12,
+            children: List.generate(
+                Constants.topSkillLevel, (index) => Text('${index + 1}')),
+            onSelectedItemChanged: (numb) {
               DB().generalSettings =
-                  generalSettings.copyWith(skillLevel: value.toInt());
-              logger.v("Skill level Slider value: $value");
+                  generalSettings.copyWith(skillLevel: numb + 1);
             },
           );
         },

--- a/src/ui/flutter_app/lib/shared/custom_drawer/custom_drawer.dart
+++ b/src/ui/flutter_app/lib/shared/custom_drawer/custom_drawer.dart
@@ -22,8 +22,10 @@ import 'dart:ui';
 import 'package:animated_text_kit/animated_text_kit.dart';
 import 'package:extended_sliver/extended_sliver.dart';
 import 'package:flutter/material.dart';
+import 'package:marquee/marquee.dart';
 import 'package:sanmill/services/database/database.dart';
 import 'package:sanmill/shared/constants.dart';
+import 'package:sanmill/shared/text_size_helper.dart';
 import 'package:sanmill/shared/theme/app_theme.dart';
 
 part 'src/controller.dart';

--- a/src/ui/flutter_app/lib/shared/custom_drawer/src/item.dart
+++ b/src/ui/flutter_app/lib/shared/custom_drawer/src/item.dart
@@ -46,6 +46,14 @@ class CustomDrawerItem<T> extends StatelessWidget {
       color: color,
     );
 
+    final titleStyle = Theme.of(context).textTheme.headline6!.copyWith(
+          fontWeight: selected ? FontWeight.w500 : FontWeight.w400,
+          color: color,
+        );
+
+    final titleSize = TextSizeHelper.boundingTextSize(title, titleStyle, maxLines: 1);
+    final isExpand = (MediaQuery.of(context).size.width * 0.75 - 44) > titleSize.width;
+
     final drawerItem = Row(
       children: <Widget>[
         const SizedBox(height: 46.0, width: 6.0),
@@ -53,13 +61,19 @@ class CustomDrawerItem<T> extends StatelessWidget {
         listItemIcon,
         const Padding(padding: EdgeInsets.all(4.0)),
         Expanded(
-          child: Text(
-            title,
-            style: Theme.of(context).textTheme.headline6!.copyWith(
-                  fontWeight: selected ? FontWeight.w500 : FontWeight.w400,
-                  color: color,
+          child: isExpand || !selected
+              ? Text(
+                  title,
+                  maxLines: 1,
+                  style: titleStyle,
+                )
+              : SizedBox(
+                  height: AppTheme.drawerItemHeight,
+                  child: Marquee(
+                    text: title,
+                    style: titleStyle,
+                  ),
                 ),
-          ),
         )
       ],
     );

--- a/src/ui/flutter_app/lib/shared/custom_drawer/src/item.dart
+++ b/src/ui/flutter_app/lib/shared/custom_drawer/src/item.dart
@@ -51,7 +51,7 @@ class CustomDrawerItem<T> extends StatelessWidget {
           color: color,
         );
 
-    final titleSize = TextSizeHelper.boundingTextSize(title, titleStyle, maxLines: 1);
+    final titleSize = TextSizeHelper.boundingTextSize(context, title, titleStyle, maxLines: 1);
     final isExpand = (MediaQuery.of(context).size.width * 0.75 * 0.9 - 46) > titleSize.width;
 
     final drawerItem = Row(

--- a/src/ui/flutter_app/lib/shared/custom_drawer/src/item.dart
+++ b/src/ui/flutter_app/lib/shared/custom_drawer/src/item.dart
@@ -52,7 +52,7 @@ class CustomDrawerItem<T> extends StatelessWidget {
         );
 
     final titleSize = TextSizeHelper.boundingTextSize(title, titleStyle, maxLines: 1);
-    final isExpand = (MediaQuery.of(context).size.width * 0.75 - 44) > titleSize.width;
+    final isExpand = (MediaQuery.of(context).size.width * 0.75 * 0.9 - 46) > titleSize.width;
 
     final drawerItem = Row(
       children: <Widget>[

--- a/src/ui/flutter_app/lib/shared/text_size_helper.dart
+++ b/src/ui/flutter_app/lib/shared/text_size_helper.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
 
-
 class TextSizeHelper {
   // Get the size of the text through textPainter
-  static Size boundingTextSize(String text, TextStyle style,  {int maxLines = 2^31, double maxWidth = double.infinity}) {
+  static Size boundingTextSize(String text, TextStyle style,
+      {int maxLines = 2 ^ 31, double maxWidth = double.infinity}) {
     if (text.isEmpty) {
       return Size.zero;
     }
     final TextPainter textPainter = TextPainter(
         textDirection: TextDirection.ltr,
-        text: TextSpan(text: text, style: style), maxLines: maxLines)
+        text: TextSpan(text: text, style: style),
+        maxLines: maxLines)
       ..layout(maxWidth: maxWidth);
     return textPainter.size;
   }

--- a/src/ui/flutter_app/lib/shared/text_size_helper.dart
+++ b/src/ui/flutter_app/lib/shared/text_size_helper.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+
+class TextSizeHelper {
+  // Get the size of the text through textPainter
+  static Size boundingTextSize(String text, TextStyle style,  {int maxLines = 2^31, double maxWidth = double.infinity}) {
+    if (text.isEmpty) {
+      return Size.zero;
+    }
+    final TextPainter textPainter = TextPainter(
+        textDirection: TextDirection.ltr,
+        text: TextSpan(text: text, style: style), maxLines: maxLines)
+      ..layout(maxWidth: maxWidth);
+    return textPainter.size;
+  }
+}

--- a/src/ui/flutter_app/lib/shared/text_size_helper.dart
+++ b/src/ui/flutter_app/lib/shared/text_size_helper.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 
 class TextSizeHelper {
   // Get the size of the text through textPainter
-  static Size boundingTextSize(String text, TextStyle style,
+  static Size boundingTextSize(
+      BuildContext context, String text, TextStyle style,
       {int maxLines = 2 ^ 31, double maxWidth = double.infinity}) {
     if (text.isEmpty) {
       return Size.zero;
@@ -10,6 +11,8 @@ class TextSizeHelper {
     final TextPainter textPainter = TextPainter(
         textDirection: TextDirection.ltr,
         text: TextSpan(text: text, style: style),
+        textScaleFactor: MediaQuery.of(context).textScaleFactor,
+        locale: Localizations.localeOf(context),
         maxLines: maxLines)
       ..layout(maxWidth: maxWidth);
     return textPainter.size;

--- a/src/ui/flutter_app/pubspec.yaml
+++ b/src/ui/flutter_app/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   intl: ^0.17.0
   json_annotation: ^4.7.0
   logger: ^1.1.0
+  marquee: ^2.2.3
   package_info_plus: ^1.4.3+1
   path_provider: ^2.0.11
   sliver_tools: ^0.2.8
@@ -45,7 +46,6 @@ dependencies:
   #    path: soundpool_windux
   url_launcher: ^6.1.6
   uuid: ^3.0.6
-  marquee: ^2.2.3
 
 dev_dependencies:
   build_runner: ^2.3.0

--- a/src/ui/flutter_app/pubspec.yaml
+++ b/src/ui/flutter_app/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   #    path: soundpool_windux
   url_launcher: ^6.1.6
   uuid: ^3.0.6
+  marquee: ^2.2.3
 
 dev_dependencies:
   build_runner: ^2.3.0


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
1. 外观设置 -> 显示语言，选择 English 上面一项，即希腊语。打开 Drawer，可以看到第2个选项 “人机对战” 对应的希腊文排列成2排，想达到的效果时，还是显示成一排，当用户点击这项后，文字如跑马灯一样从右向左滚动。或者如果能有更好的显示方式亦可，不过显示成省略号是不太合理的。进入对局，可以看到页面下方工具栏的显示异常，所有按钮都因为文字太长，而横向排列变成上下排列了。这里对于按钮下方的文字，可以考虑显示成省略号。
2. 在小屏幕手机上，打开 外观设置 -> 显示着法导航工具栏，将 “棋盘和上边缘的间距” 调到最大，返回 人机对战 界面，上下滑动页面，可以看到左上角的三个横线的导航菜单图标也跟着滑动。期望是不动，并且其位置应始终保持和设置界面中的这个图标的位置一致。
3. 点 “常规设置” -> "难度等级"，弹出的进度条不够美观，考虑改成波轮效果。

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/calcitem/Sanmill/issues/600

## :green_heart: How did you test it?
Tested on a minimum 768*1280 emulator

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
