### PR TITLE
Fix UI bug

### DIFF
--- a/src/ui/flutter_app/lib/main.dart
+++ b/src/ui/flutter_app/lib/main.dart
@@ -18,7 +18,6 @@ import 'dart:io';
 import 'dart:ui';
 
 import 'package:catcher/catcher.dart';
-import 'package:double_back_to_close_app/double_back_to_close_app.dart';
 import 'package:feedback/feedback.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -127,12 +126,9 @@ class SanmillApp extends StatelessWidget {
   }
 
   Widget _buildHome(BuildContext context) {
-    return Scaffold(
+    return const Scaffold(
       resizeToAvoidBottomInset: false,
-      body: DoubleBackToCloseApp(
-        snackBar: CustomSnackBar(S.of(context).tapBackAgainToLeave),
-        child: const Home(),
-      ),
+      body: Home(),
     );
   }
 }

--- a/src/ui/flutter_app/lib/screens/game_page/header.dart
+++ b/src/ui/flutter_app/lib/screens/game_page/header.dart
@@ -142,7 +142,7 @@ class HeaderTipState extends State<HeaderTip> {
         return Semantics(
           enabled: true,
           child: SizedBox(
-            height: 28,
+            height: 24 * DB().displaySettings.fontScale,
             child: Text(
               value == "" ? S.of(context).welcome : value,
               maxLines: 1,

--- a/src/ui/flutter_app/lib/screens/game_page/header.dart
+++ b/src/ui/flutter_app/lib/screens/game_page/header.dart
@@ -141,15 +141,18 @@ class HeaderTipState extends State<HeaderTip> {
       builder: (BuildContext context, String value, Widget? child) {
         return Semantics(
           enabled: true,
-          child: Text(
-            value == "" ? S.of(context).welcome : value,
-            maxLines: 1,
-            style: TextStyle(
-              color: DB().colorSettings.messageColor,
-              // ignore: always_specify_types
-              fontFeatures: const [FontFeature.tabularFigures()],
+          child: SizedBox(
+            height: 28,
+            child: Text(
+              value == "" ? S.of(context).welcome : value,
+              maxLines: 1,
+              style: TextStyle(
+                color: DB().colorSettings.messageColor,
+                // ignore: always_specify_types
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
             ),
-          ),
+          )
         );
       },
     );

--- a/src/ui/flutter_app/lib/screens/home.dart
+++ b/src/ui/flutter_app/lib/screens/home.dart
@@ -150,27 +150,51 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
 
     setState(() {
       assert(index != _DrawerIndex.feedback);
+      _pushRoute(index);
       _drawerIndex = index;
-      _routes.push(_drawerIndex);
       if (index.screen != null) {
         _screenView = index.screen!;
       }
     });
   }
 
-  bool _canPopRoute() {
-    if (_routes.length > 1) {
+  bool _isGame(_DrawerIndex index) {
+    return index.index < 4;
+  }
+
+  void _pushRoute(_DrawerIndex index) {
+    final bool curIsGame = _isGame(_drawerIndex);
+    final bool nextIsGame = _isGame(index);
+    if (curIsGame && !nextIsGame) {
+      _routes.push(index);
+    } else if (!curIsGame && nextIsGame) {
+      _routes.clear();
+      _routes.push(index);
+    } else {
       _routes.pop();
-      setState(() {
-        _drawerIndex = _routes.top();
-        if (_drawerIndex.screen != null) {
-          _screenView = _drawerIndex.screen!;
-        }
-        debugPrint('_drawerIndex: $_drawerIndex');
-      });
+      _routes.push(index);
+    }
+    setState(() {});
+  }
+
+  bool _canPopRoute() {
+    if (Navigator.canPop(context)) {
+      Navigator.of(context).pop();
       return true;
     } else {
-      return false;
+      if (_routes.length > 1) {
+        _routes.pop();
+        setState(() {
+          _drawerIndex = _routes.top();
+          if (_drawerIndex.screen != null) {
+            _screenView = _drawerIndex.screen!;
+          }
+          debugPrint('_drawerIndex: $_drawerIndex');
+        });
+        return true;
+      } else {
+        return false;
+      }
     }
   }
 
@@ -190,6 +214,12 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
           break;
       }
     }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _routes.push(_drawerIndex);
   }
 
   @override

--- a/src/ui/flutter_app/lib/screens/home.dart
+++ b/src/ui/flutter_app/lib/screens/home.dart
@@ -34,7 +34,10 @@ import '../services/logger.dart';
 import '../services/mill/mill.dart';
 import '../shared/constants.dart';
 import '../shared/custom_drawer/custom_drawer.dart';
+import '../shared/double_back_to_close_app.dart';
 import '../shared/privacy_dialog.dart';
+import '../shared/scaffold_messenger.dart';
+import '../shared/stack_list.dart';
 import 'about_page.dart';
 import 'appearance_settings/appearance_settings_page.dart';
 import 'game_page/game_page.dart';
@@ -118,6 +121,7 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
 
   Widget _screenView = _DrawerIndex.humanVsAi.screen!;
   _DrawerIndex _drawerIndex = _DrawerIndex.humanVsAi;
+  final StackList<_DrawerIndex> _routes = StackList<_DrawerIndex>();
 
   /// Callback from drawer for replace screen
   /// as user need with passing DrawerIndex (Enum index)
@@ -147,10 +151,27 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
     setState(() {
       assert(index != _DrawerIndex.feedback);
       _drawerIndex = index;
+      _routes.push(_drawerIndex);
       if (index.screen != null) {
         _screenView = index.screen!;
       }
     });
+  }
+
+  bool _canPopRoute() {
+    if (_routes.length > 1) {
+      _routes.pop();
+      setState(() {
+        _drawerIndex = _routes.top();
+        if (_drawerIndex.screen != null) {
+          _screenView = _drawerIndex.screen!;
+        }
+        debugPrint('_drawerIndex: $_drawerIndex');
+      });
+      return true;
+    } else {
+      return false;
+    }
   }
 
   void firstRun(BuildContext context) {
@@ -263,13 +284,20 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
       ),
     ];
 
-    return CustomDrawer(
-      controller: _controller,
-      header: CustomDrawerHeader(
-        title: S.of(context).appName,
+    return DoubleBackToCloseApp(
+      snackBar: CustomSnackBar(S.of(context).tapBackAgainToLeave),
+      willBack: () {
+        return !_canPopRoute();
+      },
+      child: CustomDrawer(
+        controller: _controller,
+        header: CustomDrawerHeader(
+          title: S.of(context).appName,
+        ),
+        items: drawerItems,
+        disabledGestures: _drawerIndex.index < 4,
+        child: _screenView,
       ),
-      items: drawerItems,
-      child: _screenView,
     );
   }
 

--- a/src/ui/flutter_app/lib/screens/home.dart
+++ b/src/ui/flutter_app/lib/screens/home.dart
@@ -178,23 +178,18 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
   }
 
   bool _canPopRoute() {
-    if (Navigator.canPop(context)) {
-      Navigator.of(context).pop();
+    if (_routes.length > 1) {
+      _routes.pop();
+      setState(() {
+        _drawerIndex = _routes.top();
+        if (_drawerIndex.screen != null) {
+          _screenView = _drawerIndex.screen!;
+        }
+        debugPrint('_drawerIndex: $_drawerIndex');
+      });
       return true;
     } else {
-      if (_routes.length > 1) {
-        _routes.pop();
-        setState(() {
-          _drawerIndex = _routes.top();
-          if (_drawerIndex.screen != null) {
-            _screenView = _drawerIndex.screen!;
-          }
-          debugPrint('_drawerIndex: $_drawerIndex');
-        });
-        return true;
-      } else {
-        return false;
-      }
+      return false;
     }
   }
 

--- a/src/ui/flutter_app/lib/services/init_system_ui.dart
+++ b/src/ui/flutter_app/lib/services/init_system_ui.dart
@@ -37,7 +37,7 @@ void _initUI() {
       const SystemUiOverlayStyle(
         statusBarColor: Colors.transparent,
         statusBarBrightness: Brightness.light,
-        statusBarIconBrightness: Brightness.dark,
+        statusBarIconBrightness: Brightness.light,
         systemNavigationBarColor: Colors.black,
         systemNavigationBarIconBrightness: Brightness.dark,
       ),

--- a/src/ui/flutter_app/lib/shared/double_back_to_close_app.dart
+++ b/src/ui/flutter_app/lib/shared/double_back_to_close_app.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+typedef WillBackCall = bool Function();
+
+/// Allows the user to close the app by double tapping the back-button.
+///
+/// You must specify a [SnackBar], so it can be shown when the user taps the
+/// back-button.
+///
+/// Since the back-button is an Android feature, this Widget is going to be
+/// nothing but the own [child] if the current platform is anything but Android.
+class DoubleBackToCloseApp extends StatefulWidget {
+
+  /// Creates a widget that allows the user to close the app by double tapping
+  /// the back-button.
+  const DoubleBackToCloseApp({
+    super.key,
+    required this.snackBar,
+    required this.child,
+    this.willBack,
+  });
+  /// The [SnackBar] shown when the user taps the back-button.
+  final SnackBar snackBar;
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  /// Return false to ignore the component processing, return true to continue
+  final WillBackCall? willBack;
+
+  @override
+  State<DoubleBackToCloseApp> createState() => _DoubleBackToCloseAppState();
+}
+
+class _DoubleBackToCloseAppState extends State<DoubleBackToCloseApp> {
+  /// Completer that gets completed whenever the current snack-bar is closed.
+  Completer<SnackBarClosedReason> _closedCompleter = Completer<SnackBarClosedReason>()
+    ..complete(SnackBarClosedReason.remove);
+
+  /// Returns whether the current platform is Android.
+  bool get _isAndroid => Theme.of(context).platform == TargetPlatform.android;
+
+  /// Returns whether the [DoubleBackToCloseApp.snackBar] is currently visible.
+  bool get _isSnackBarVisible => !_closedCompleter.isCompleted;
+
+  /// Returns whether the next back navigation of this route will be handled
+  /// internally.
+  ///
+  /// Returns true when there's a widget that inserted an entry into the
+  /// local-history of the current route, in order to handle pop. This is done
+  /// by [Drawer], for example, so it can close on pop.
+  bool get _willHandlePopInternally =>
+      ModalRoute.of(context)?.willHandlePopInternally ?? false;
+
+  @override
+  Widget build(BuildContext context) {
+    assert(() {
+      _ensureThatContextContainsScaffold();
+      return true;
+    }());
+
+    if (_isAndroid) {
+      return WillPopScope(
+        onWillPop: _handleWillPop,
+        child: widget.child,
+      );
+    } else {
+      return widget.child;
+    }
+  }
+
+  /// Handles [WillPopScope.onWillPop].
+  Future<bool> _handleWillPop() async {
+    if (widget.willBack != null && !widget.willBack!.call()) {
+      return false;
+    }
+
+    if (_isSnackBarVisible || _willHandlePopInternally) {
+      return true;
+    } else {
+      final ScaffoldMessengerState scaffoldMessenger = ScaffoldMessenger.of(context);
+      scaffoldMessenger.hideCurrentSnackBar();
+      _closedCompleter = scaffoldMessenger
+          .showSnackBar(widget.snackBar)
+          .closed
+          .wrapInCompleter();
+      return false;
+    }
+  }
+
+  /// Throws a [FlutterError] if this widget was not wrapped in a [Scaffold].
+  void _ensureThatContextContainsScaffold() {
+    if (Scaffold.maybeOf(context) == null) {
+      throw FlutterError(
+        '`DoubleBackToCloseApp` must be wrapped in a `Scaffold`.',
+      );
+    }
+  }
+}
+
+extension<T> on Future<T> {
+  /// Returns a [Completer] that allows checking for this [Future]'s completion.
+  ///
+  /// See https://stackoverflow.com/a/69731240/6696558.
+  Completer<T> wrapInCompleter() {
+    final Completer<T> completer = Completer<T>();
+    then(completer.complete).catchError(completer.completeError);
+    return completer;
+  }
+}

--- a/src/ui/flutter_app/lib/shared/painters/src/piece_painter.dart
+++ b/src/ui/flutter_app/lib/shared/painters/src/piece_painter.dart
@@ -63,7 +63,7 @@ class PiecePainter extends CustomPainter {
     final Path shadowPath = Path();
     final List<_PiecePaintParam> piecesToDraw = <_PiecePaintParam>[];
 
-    final double pieceWidth = size.width * DB().displaySettings.pieceWidth / 7;
+    final double pieceWidth = size.width * DB().displaySettings.pieceWidth * 0.8 / 7;
     final double animatedPieceWidth = pieceWidth * animationValue;
 
     // Draw pieces on board

--- a/src/ui/flutter_app/lib/shared/painters/src/piece_painter.dart
+++ b/src/ui/flutter_app/lib/shared/painters/src/piece_painter.dart
@@ -63,7 +63,7 @@ class PiecePainter extends CustomPainter {
     final Path shadowPath = Path();
     final List<_PiecePaintParam> piecesToDraw = <_PiecePaintParam>[];
 
-    final double pieceWidth = size.width * DB().displaySettings.pieceWidth * 0.8 / 7;
+    final double pieceWidth = size.width * DB().displaySettings.pieceWidth / 7;
     final double animatedPieceWidth = pieceWidth * animationValue;
 
     // Draw pieces on board

--- a/src/ui/flutter_app/lib/shared/stack_list.dart
+++ b/src/ui/flutter_app/lib/shared/stack_list.dart
@@ -1,0 +1,100 @@
+import 'dart:collection';
+import 'dart:core';
+
+import 'package:flutter/foundation.dart';
+
+class StackList<T> {
+  /// Default constructor sets the maximum stack size to 'no limit.'
+  StackList() {
+    _sizeMax = noLimit;
+  }
+
+  /// Constructor in which you can specify maximum number of entries.
+  /// This maximum is a limit that is enforced as entries are pushed on to the stack
+  /// to prevent stack growth beyond a maximum size. There is no pre-allocation of
+  /// slots for entries at any time in this library.
+  StackList.sized(int sizeMax) {
+    if (sizeMax < 2) {
+      throw Exception('Error: stack size must be 2 entries or more ');
+    } else {
+      _sizeMax = sizeMax;
+    }
+  }
+
+  final ListQueue<T> _list = ListQueue<T>();
+
+  final int noLimit = -1;
+
+  /// the maximum number of entries allowed on the stack. -1 = no limit.
+  int _sizeMax = 0;
+
+  /// Returns a list of T elements contained in the Stack
+  List<T> toList() => _list.toList();
+
+  /// check if the stack is empty.
+  bool get isEmpty => _list.isEmpty;
+
+  /// check if the stack is not empty.
+  bool get isNotEmpty => _list.isNotEmpty;
+
+  /// push element in top of the stack.
+  void push(T e) {
+    if (_sizeMax == noLimit || _list.length < _sizeMax) {
+      _list.addLast(e);
+    } else {
+      throw Exception(
+          'Error: cannot add element. Stack already at maximum size of: $_sizeMax elements');
+    }
+  }
+
+  /// get the top of the stack and delete it.
+  T pop() {
+    if (isEmpty) {
+      throw Exception(
+        "Can't use pop with empty stack\n consider "
+        'checking for size or isEmpty before calling pop',
+      );
+    }
+    final T res = _list.last;
+    _list.removeLast();
+    return res;
+  }
+
+  /// get the top of the stack without deleting it.
+  T top() {
+    if (isEmpty) {
+      throw Exception(
+        "Can't use top with empty stack\n consider "
+        'checking for size or isEmpty before calling top',
+      );
+    }
+    return _list.last;
+  }
+
+  /// get the size of the stack.
+  int size() {
+    return _list.length;
+  }
+
+  /// get the length of the stack.
+  int get length => size();
+
+  /// returns true if element is found in the stack
+  bool contains(T x) {
+    return _list.contains(x);
+  }
+
+  /// removes all elements from the stack
+  void clear() {
+    while (isNotEmpty) {
+      _list.removeLast();
+    }
+  }
+
+  /// print stack
+  void print() {
+    List<T>.from(_list).reversed.toList().forEach((T element) {
+      debugPrint(element.toString());
+    });
+  }
+}

--- a/src/ui/flutter_app/lib/shared/theme/app_theme.dart
+++ b/src/ui/flutter_app/lib/shared/theme/app_theme.dart
@@ -136,7 +136,7 @@ class AppTheme {
 
   static const double boardMargin = 10.0;
   static const double boardBorderRadius = 5.0;
-  static const double boardPadding = 25.0;
+  static const double boardPadding = 30.0;
   static const double sizedBoxHeight = 16.0;
 
   static const double drawerItemHeight = 46.0;

--- a/src/ui/flutter_app/pubspec.yaml
+++ b/src/ui/flutter_app/pubspec.yaml
@@ -11,12 +11,12 @@ dependencies:
   catcher:
     git:
       url: https://gitlab.com/calcitem/catcher.git
+      ref: master
       #url: https://github.com/ThexXTURBOXx/catcher.git
   collection: ^1.16.0
   copy_with_extension: ^4.0.4
   cupertino_icons: ^1.0.5
   device_info_plus: ^7.0.1
-  double_back_to_close_app: ^2.1.0
   extended_sliver: ^2.1.3
   feedback: ^2.5.0
   filesystem_picker: ^3.1.0


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
按返回键，会提示“再按一次返回键退出”，再按一次就退出。预期是期望返回上个页面。
 棋盘上方的提示信息，当显示文字为中文或纯英文时，高度不一，棋盘会上下跳动。
 最好提供一个选项，棋盘不响应左右滑动事件，这个事件会打开 Drawer。
在棋盘页面和设置页面切换时，存在状态栏图标颜色变化的问题，希望固定为白色。
 有的时候棋盘边缘的棋子显示不正常。偶然会出现边缘模糊。可能是棋盘不够大？

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/calcitem/Sanmill/issues/240
https://github.com/calcitem/Sanmill/issues/204

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
