### PR TITLE
some adjustments for compiling on Linux

### DIFF
--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(MillGame)
 
+set(CMAKE_CXX_STANDARD 17)
+
 find_package(Qt5 REQUIRED COMPONENTS Core Gui Multimedia Widgets)
 
 include_directories(${CMAKE_SOURCE_DIR} ../../../include ../.. ../../test ../../perfect)
@@ -13,12 +15,12 @@ file(GLOB FORMS *.ui)
 file(GLOB RESOURCES *.qrc)
 file(GLOB RESOURCE_FILES *.rc)
 
-add_compile_options(/std:c++17)
+# add_compile_options(/std:c++17)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /W4")
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /W4")
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS} ${FORMS} ${RESOURCES} ${RESOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} shlwapi Qt5::Core Qt5::Gui Qt5::Multimedia Qt5::Widgets)
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Multimedia Qt5::Widgets)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON AUTOUIC ON AUTORCC ON)
 

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(MillGame)
 
-set(CMAKE_CXX_STANDARD 17)
+if(UNIX)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 find_package(Qt5 REQUIRED COMPONENTS Core Gui Multimedia Widgets)
 
@@ -15,12 +17,17 @@ file(GLOB FORMS *.ui)
 file(GLOB RESOURCES *.qrc)
 file(GLOB RESOURCE_FILES *.rc)
 
-# add_compile_options(/std:c++17)
-
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /W4")
+if(MSVC)
+  add_compile_options(/std:c++17)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /W4")
+endif()
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS} ${FORMS} ${RESOURCES} ${RESOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Multimedia Qt5::Widgets)
+if(MSVC)
+  target_link_libraries(${PROJECT_NAME} shlwapi Qt5::Core Qt5::Gui Qt5::Multimedia Qt5::Widgets)
+else()
+  target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Multimedia Qt5::Widgets)
+endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON AUTOUIC ON AUTORCC ON)
 


### PR DESCRIPTION

## :scroll: Description
1 - replace 'add_compile_options(/std:c++17)' as set(CMAKE_CXX_STANDARD 17); 
2 - remove unnecessary options.


## :bulb: Motivation and Context
Just for compiling on Linux OS.


## :green_heart: How did you test it?
Test passed on ubuntu22.04 + gcc and g++ with version 11.2.0.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
