### PR TITLE
Update agent instructions with documentation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENT INSTRUCTIONS
+
+## Commit Workflow
+- Before staging or committing changes, run `./format.sh s` from the
+  repository root and wait for it to finish.
+- Only run `git add` and `git commit` after the formatting script has
+  completed successfully.
+
+## Commit Message Rules
+- Every commit message must include a body paragraph in addition to the
+  subject line.
+- Wrap all lines in the commit subject and body at 72 characters.
+
+## Documentation
+- After finishing your code changes, do not create new Markdown documents
+  solely to summarize the modifications.


### PR DESCRIPTION
## Summary
- add a documentation section clarifying that no new Markdown summaries are needed after completing changes

## Testing
- ./format.sh s *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaea63fcc8320b20e47f90d0070b8