### PR TITLE
Automate Flutter SDK provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -446,6 +446,7 @@ flutter_export_environment.sh
 .autogit
 build/
 out/
+/.tools/
 /src/*.stackdump
 
 # Snapcraft

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -143,6 +143,7 @@ make build ARCH=x86-64-modern
 ### Flutter App
 
 运行`./flutter-init.sh`，然后使用 Android Studio 或 Visual Studio Code 打开 `src/ui/flutter_app` 来构建 Flutter App。
+该脚本会在系统未安装所需版本时，自动在 `.tools/flutter` 中下载并配置 Flutter 3.29.3，确保仓库始终使用预期的 SDK。
 
 我们使用编译期环境配置来启用代码的特定部分：
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ When reporting an issue or a bug, please provide information about the version a
 ### Flutter App
 
 To build the Flutter app, run `./flutter-init.sh`, and then use Android Studio or Visual Studio Code to open `src/ui/flutter_app`.
+The script automatically provisions Flutter **3.29.3** in `.tools/flutter` when the required SDK
+isn't already available on your system, ensuring the repository always uses the expected version.
 
 We use compile-time environment configs to enable specific parts of the code:
 

--- a/flutter-init.sh
+++ b/flutter-init.sh
@@ -1,35 +1,30 @@
 #!/bin/bash
+set -euo pipefail
 
-# Navigate to the Flutter app directory
-cd src/ui/flutter_app || exit
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/scripts/ensure_flutter.sh"
 
-# Paths for generated files
-GEN_FILE_PATH=lib/generated
-FLUTTER_VERSION_FILE=$GEN_FILE_PATH/flutter_version.dart
-GIT_INFO_PATH=assets/files
-GIT_BRANCH_FILE=$GIT_INFO_PATH/git-branch.txt
-GIT_REVISION_FILE=$GIT_INFO_PATH/git-revision.txt
+ensure_flutter_on_path
 
-# Create necessary directories
-mkdir -p "$GIT_INFO_PATH" "$GEN_FILE_PATH" || true
+APP_DIR="${SCRIPT_DIR}/src/ui/flutter_app"
+GEN_FILE_PATH="${APP_DIR}/lib/generated"
+FLUTTER_VERSION_FILE="${GEN_FILE_PATH}/flutter_version.dart"
+GIT_INFO_PATH="${APP_DIR}/assets/files"
+GIT_BRANCH_FILE="${GIT_INFO_PATH}/git-branch.txt"
+GIT_REVISION_FILE="${GIT_INFO_PATH}/git-revision.txt"
 
-# Generate Git branch and revision files
-git symbolic-ref --short HEAD > "$GIT_BRANCH_FILE"
-git rev-parse HEAD > "$GIT_REVISION_FILE"
+mkdir -p "${GIT_INFO_PATH}" "${GEN_FILE_PATH}" || true
 
-# Disable analytics
+git -C "${SCRIPT_DIR}" symbolic-ref --short HEAD > "${GIT_BRANCH_FILE}"
+git -C "${SCRIPT_DIR}" rev-parse HEAD > "${GIT_REVISION_FILE}"
+
 flutter config --no-analytics
 
-# Get Flutter packages
-flutter pub get
+( cd "${APP_DIR}" && flutter pub get )
 
-# Generate Flutter version file
-echo "const Map<String, String> flutterVersion =" > "$FLUTTER_VERSION_FILE"
-flutter --version --machine | tee -a "$FLUTTER_VERSION_FILE"
-sed -i.bak -e ':a' -e 'N' -e '$!ba' -e 's/}\([[:space:]]*\)$/};\1/' "$FLUTTER_VERSION_FILE" && rm "${FLUTTER_VERSION_FILE}.bak"
+echo "const Map<String, String> flutterVersion =" > "${FLUTTER_VERSION_FILE}"
+flutter --version --machine | tee -a "${FLUTTER_VERSION_FILE}"
+sed -i.bak -e ':a' -e 'N' -e '$!ba' -e 's/}\([[:space:]]*\)$/};\1/' "${FLUTTER_VERSION_FILE}" && rm "${FLUTTER_VERSION_FILE}.bak"
 
-# Run code generation
-dart run build_runner build --delete-conflicting-outputs
-
-# Run gen-l10n
-flutter gen-l10n
+( cd "${APP_DIR}" && dart run build_runner build --delete-conflicting-outputs )
+( cd "${APP_DIR}" && flutter gen-l10n )

--- a/flutter-linux-init.sh
+++ b/flutter-linux-init.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
+set -euo pipefail
 
-./flutter-init.sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/scripts/ensure_flutter.sh"
+
+ensure_flutter_on_path
+
+"${SCRIPT_DIR}/flutter-init.sh"
 
 flutter config --enable-linux-desktop
 
-cd src/ui/flutter_app
-flutter create --platforms=linux .
+( cd "${SCRIPT_DIR}/src/ui/flutter_app" && flutter create --platforms=linux . )

--- a/flutter-windows-init.sh
+++ b/flutter-windows-init.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
+set -euo pipefail
 
-./flutter-init.sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/scripts/ensure_flutter.sh"
+
+ensure_flutter_on_path
+
+"${SCRIPT_DIR}/flutter-init.sh"
 
 flutter config --enable-windows-desktop
-#flutter create --platforms=windows .
+# flutter create --platforms=windows .

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -7,3 +7,4 @@
 *.m
 *.sh
 *.pl
+!ensure_flutter.sh

--- a/scripts/ensure_flutter.sh
+++ b/scripts/ensure_flutter.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+# When sourced, this script provides helpers for ensuring that the
+# required Flutter SDK version is available. When executed directly it
+# will download the SDK if necessary and print the resolved SDK path.
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+fi
+
+SANMILL_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SANMILL_REPO_ROOT="$(cd "${SANMILL_SCRIPT_DIR}/.." && pwd)"
+
+: "${REQUIRED_FLUTTER_VERSION:=3.29.3}"
+: "${FLUTTER_CHANNEL:=stable}"
+: "${FLUTTER_DOWNLOAD_BASE_URL:=https://storage.googleapis.com/flutter_infra_release/releases}"
+: "${FLUTTER_TOOL_DIR:=${SANMILL_REPO_ROOT}/.tools/flutter}"
+
+FLUTTER_SDK_PATH=""
+
+flutter__detect_system_flutter() {
+  if ! command -v flutter >/dev/null 2>&1; then
+    return 1
+  fi
+
+  local flutter_cmd
+  flutter_cmd="$(command -v flutter)"
+
+  local version_line
+  if ! version_line="$("${flutter_cmd}" --version 2>/dev/null | head -n 1)"; then
+    return 1
+  fi
+
+  # Expected format: "Flutter 3.29.3 • channel stable • ..."
+  local version
+  version="$(printf '%s' "${version_line}" | awk '{print $2}')"
+  if [[ "${version}" != "${REQUIRED_FLUTTER_VERSION}" ]]; then
+    echo "Found Flutter ${version}, but ${REQUIRED_FLUTTER_VERSION} is required." >&2
+    return 1
+  fi
+
+  local flutter_bin_dir
+  flutter_bin_dir="$(cd "$(dirname "${flutter_cmd}")" && pwd)"
+  FLUTTER_SDK_PATH="$(cd "${flutter_bin_dir}/.." && pwd)"
+  return 0
+}
+
+flutter__resolve_archive() {
+  local uname_s
+  uname_s="$(uname -s 2>/dev/null || echo unknown)"
+  case "${uname_s}" in
+    Linux*)
+      printf 'linux flutter_linux_%s-%s.tar.xz\n' "${REQUIRED_FLUTTER_VERSION}" "${FLUTTER_CHANNEL}"
+      ;;
+    Darwin*)
+      printf 'macos flutter_macos_%s-%s.zip\n' "${REQUIRED_FLUTTER_VERSION}" "${FLUTTER_CHANNEL}"
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      printf 'windows flutter_windows_%s-%s.zip\n' "${REQUIRED_FLUTTER_VERSION}" "${FLUTTER_CHANNEL}"
+      ;;
+    *)
+      printf 'unsupported %s\n' "${uname_s}"
+      return 1
+      ;;
+  esac
+}
+
+flutter__download_sdk() {
+  local archive_info
+  archive_info="$(flutter__resolve_archive)" || {
+    echo "Unsupported platform for Flutter SDK download." >&2
+    return 1
+  }
+
+  local platform archive_name
+  platform="${archive_info%% *}"
+  archive_name="${archive_info#* }"
+  local url
+  url="${FLUTTER_DOWNLOAD_BASE_URL}/${FLUTTER_CHANNEL}/${platform}/${archive_name}"
+
+  echo "Downloading Flutter SDK ${REQUIRED_FLUTTER_VERSION} (${platform})..." >&2
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${tmp_dir}"' RETURN
+
+  local archive_path
+  archive_path="${tmp_dir}/${archive_name}"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fL "${url}" -o "${archive_path}"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -O "${archive_path}" "${url}"
+  else
+    echo "Neither curl nor wget is available to download Flutter SDK." >&2
+    return 1
+  fi
+
+  rm -rf "${tmp_dir}/flutter"
+
+  if [[ "${archive_name}" == *.tar.xz ]]; then
+    tar -xf "${archive_path}" -C "${tmp_dir}"
+  else
+    if ! command -v unzip >/dev/null 2>&1; then
+      echo "The unzip command is required to extract the Flutter SDK archive." >&2
+      return 1
+    fi
+    unzip -q "${archive_path}" -d "${tmp_dir}"
+  fi
+
+  if [[ ! -d "${tmp_dir}/flutter" ]]; then
+    echo "Unexpected Flutter SDK archive layout retrieved from ${url}." >&2
+    return 1
+  fi
+
+  local target_dir
+  target_dir="${FLUTTER_TOOL_DIR}/${REQUIRED_FLUTTER_VERSION}"
+  mkdir -p "${FLUTTER_TOOL_DIR}"
+  rm -rf "${target_dir}"
+  mv "${tmp_dir}/flutter" "${target_dir}"
+  FLUTTER_SDK_PATH="${target_dir}"
+
+  rm -rf "${tmp_dir}"
+  trap - RETURN
+}
+
+ensure_flutter_sdk() {
+  if [[ -n "${FLUTTER_SDK_PATH}" && -x "${FLUTTER_SDK_PATH}/bin/flutter" ]]; then
+    return 0
+  fi
+
+  local target_dir
+  target_dir="${FLUTTER_TOOL_DIR}/${REQUIRED_FLUTTER_VERSION}"
+  if [[ -x "${target_dir}/bin/flutter" ]]; then
+    FLUTTER_SDK_PATH="${target_dir}"
+    return 0
+  fi
+
+  if flutter__detect_system_flutter; then
+    return 0
+  fi
+
+  flutter__download_sdk
+}
+
+ensure_flutter_on_path() {
+  ensure_flutter_sdk
+  export FLUTTER_HOME="${FLUTTER_SDK_PATH}"
+  case ":${PATH}:" in
+    *:"${FLUTTER_SDK_PATH}/bin":*) ;;
+    *) export PATH="${FLUTTER_SDK_PATH}/bin:${PATH}" ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  ensure_flutter_sdk
+  printf '%s\n' "${FLUTTER_SDK_PATH}"
+fi

--- a/scripts/flutter-pub-upgrade.sh
+++ b/scripts/flutter-pub-upgrade.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
+set -euo pipefail
 
-cd ../src/ui/flutter_app
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/ensure_flutter.sh"
 
-flutter pub outdated
+ensure_flutter_on_path
 
-flutter pub upgrade --major-versions
+APP_DIR="${SCRIPT_DIR}/../src/ui/flutter_app"
 
-
+( cd "${APP_DIR}" && flutter pub outdated )
+( cd "${APP_DIR}" && flutter pub upgrade --major-versions )


### PR DESCRIPTION
## Summary
- add scripts/ensure_flutter.sh to provision Flutter 3.29.3 and expose helpers that put the SDK on PATH
- update the Flutter init utilities to source the helper, share absolute paths, and ignore the cached .tools directory
- document the new automatic setup workflow in both README files

## Testing
- ./format.sh s

------
https://chatgpt.com/codex/tasks/task_e_68cdf73c71908320b450ab409a2a22ce