### PR TITLE
Expose save image option via screenshot service

### DIFF
--- a/src/ui/flutter_app/lib/game_page/widgets/modals/game_options_modal.dart
+++ b/src/ui/flutter_app/lib/game_page/widgets/modals/game_options_modal.dart
@@ -9,9 +9,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../../generated/intl/l10n.dart';
-import '../../../shared/config/constants.dart';
 import '../../../shared/database/database.dart';
 import '../../../shared/services/logger.dart';
+import '../../../shared/services/screenshot_service.dart';
 import '../../../shared/themes/app_theme.dart';
 import '../../../shared/widgets/custom_spacer.dart';
 import '../../services/mill.dart';
@@ -165,9 +165,9 @@ class GameOptionsModal extends StatelessWidget {
               child: Text(S.of(context).shareGIF),
             ),
           ),
-        // TODO: Support other platforms (Depend on native_screenshot package)
-        if (Constants.isAndroid10Plus == true) const CustomSpacer(),
-        if (Constants.isAndroid10Plus == true)
+        // Available on Android 10+ and iOS via native_screenshot support
+        if (ScreenshotService.isSupportedPlatform()) const CustomSpacer(),
+        if (ScreenshotService.isSupportedPlatform())
           SimpleDialogOption(
             key: const Key('save_image_option'),
             onPressed: () async {

--- a/src/ui/flutter_app/lib/shared/services/screenshot_service.dart
+++ b/src/ui/flutter_app/lib/shared/services/screenshot_service.dart
@@ -15,6 +15,7 @@ import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
 import '../../game_page/services/mill.dart';
+import '../config/constants.dart';
 import '../database/database.dart';
 import '../widgets/snackbars/scaffold_messenger.dart';
 import 'environment_config.dart';
@@ -66,7 +67,10 @@ class ScreenshotService {
     await saveImage(finalImage, filename);
   }
 
-  static bool isSupportedPlatform() => !kIsWeb && Platform.isAndroid;
+  static bool isSupportedPlatform() =>
+      !kIsWeb &&
+      (Platform.isIOS ||
+          (Platform.isAndroid && Constants.isAndroid10Plus));
 
   static String determineFilename(String? filename, String storageLocation) {
     if (filename != null && storageLocation != 'gallery') {


### PR DESCRIPTION
## Summary
- reuse ScreenshotService in the game options modal and update the button comment
- gate the save image option behind ScreenshotService.isSupportedPlatform
- extend the screenshot service helper to cover Android 10+ and iOS platforms

## Testing
- ./format.sh s *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce89970ba88320a87e50aaa0707c48