### PR TITLE
Fix loss of mill removals when special captures trigger

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -150,7 +150,7 @@ ExtMove *generate<REMOVE>(Position &pos, ExtMove *moveList)
         case ActiveCaptureMode::none:
             allowCustodian = custodianTargets != 0;
             allowIntervention = interventionTargets != 0;
-            if (pendingMill > performed) {
+            if (pendingMill > 0) {
                 allowGeneral = true;
             } else if (!allowCustodian && !allowIntervention &&
                        removalCount > 0) {
@@ -160,19 +160,19 @@ ExtMove *generate<REMOVE>(Position &pos, ExtMove *moveList)
         case ActiveCaptureMode::custodian:
             if (custodianCount > 0) {
                 allowCustodian = custodianTargets != 0;
-            } else if (pendingMill > performed || removalCount > 0) {
+            } else if (pendingMill > 0 || removalCount > 0) {
                 allowGeneral = true;
             }
             break;
         case ActiveCaptureMode::intervention:
             if (interventionCount > 0) {
                 allowIntervention = interventionTargets != 0;
-            } else if (pendingMill > performed || removalCount > 0) {
+            } else if (pendingMill > 0 || removalCount > 0) {
                 allowGeneral = true;
             }
             break;
         case ActiveCaptureMode::mill:
-            if (pendingMill > performed || removalCount > 0) {
+            if (pendingMill > 0 || removalCount > 0) {
                 allowGeneral = true;
             }
             break;


### PR DESCRIPTION
## Summary
- keep pending mill removals when special captures trigger by summing mill, custodian, and intervention quotas
- allow general removals after custodian/intervention targets are cleared and decrement the pending mill counter
- mirror the engine changes in the Flutter position logic and expose the remaining-mill checks to remove move generation

## Testing
- ./format.sh s *(fails: dart not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d16b37361c8320bfeb04d08279ccbc