### PR TITLE
Align Dart capture flow with C++ logic

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1643,7 +1643,16 @@ bool Position::remove_piece(Square s, bool updateRecord)
         const bool isInterventionTarget = (interventionTargets & mask) != 0;
         isCaptureTarget = isCustodianTarget || isInterventionTarget;
 
+        const bool hasPendingCustodian =
+            custodianCount > 0 && custodianTargets != 0;
+        const bool hasPendingIntervention =
+            interventionCount > 0 && interventionTargets != 0;
+
         if (mode == ActiveCaptureMode::none) {
+            if (!isCaptureTarget &&
+                (hasPendingCustodian || hasPendingIntervention)) {
+                return false;
+            }
             if (isInterventionTarget && interventionCount > 0) {
                 mode = ActiveCaptureMode::intervention;
                 quota = std::max(interventionCount, 2);


### PR DESCRIPTION
## Summary
- align the Dart remove flow's mill-mode guard with the engine's pending-capture logic
- mirror the C++ removal state initialization so custodian/intervention quotas match

## Testing
- ./format.sh s *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d248038c83208512630d8b22f3ef