### PR TITLE
Add Flutter clean steps to repository cleanup

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,12 +1,32 @@
 #!/bin/bash
 
-mv src/ui/flutter_app/android/key.jks ../
-mv src/ui/flutter_app/android/key.properties ../
+set -euo pipefail
+
+FLUTTER_APP_DIR="src/ui/flutter_app"
+
+cleanup_keys() {
+    mv ../key.jks "${FLUTTER_APP_DIR}/android/" 2>/dev/null || true
+    mv ../key.properties "${FLUTTER_APP_DIR}/android/" 2>/dev/null || true
+}
+
+mv "${FLUTTER_APP_DIR}/android/key.jks" ../
+mv "${FLUTTER_APP_DIR}/android/key.properties" ../
+trap cleanup_keys EXIT
+
+if command -v flutter >/dev/null 2>&1; then
+    echo "Running flutter clean..."
+    (cd "${FLUTTER_APP_DIR}" && flutter clean)
+
+    echo "Removing pubspec.lock to refresh dependency resolution..."
+    rm -f "${FLUTTER_APP_DIR}/pubspec.lock"
+else
+    echo "Flutter is not available in PATH; skipping flutter clean and pubspec.lock removal."
+fi
 
 git clean -fdx
 
-mv ../key.jks src/ui/flutter_app/android/
-mv ../key.properties src/ui/flutter_app/android/
+cleanup_keys
+trap - EXIT
 
 if [ "$(uname)" == "Darwin" ]; then
     echo "TODO: macOS"


### PR DESCRIPTION
## Summary
- add Flutter clean and pubspec.lock removal to the clean script to clear Dart build artifacts
- guard Android keystore restoration with a trap and enable strict shell error handling

## Testing
- ./format.sh s *(fails: dart: command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef04aa9c88320a1b707decd50fc89)