### PR TITLE
Fix empty miniboard on Mill moves page

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -13,16 +13,25 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
+        binutils \
+        clang \
         pkg-config \
         libssl-dev \
         clang-format \
+        cmake \
         curl \
         ca-certificates \
         git \
+        libgstreamer-plugins-base1.0-dev \
+        libgstreamer1.0-dev \
+        libgtk-3-dev \
+        lld \
+        ninja-build \
         unzip \
         xz-utils \
         zip \
         xvfb \
+        xdg-user-dirs \
         libglu1-mesa \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -3,5 +3,5 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "install": "cargo fetch && bash ./flutter-init.sh"
+  "install": "cargo fetch && bash ./flutter-init.sh && apt-get update && apt-get install -y --no-install-recommends xdg-user-dirs && xdg-user-dirs-update && cd src/ui/flutter_app && flutter precache --linux"
 }

--- a/src/ui/flutter_app/lib/games/mill/mill_session_recorder_bridge.dart
+++ b/src/ui/flutter_app/lib/games/mill/mill_session_recorder_bridge.dart
@@ -88,7 +88,11 @@ class MillSessionRecorderBridge {
     if (side == null) {
       return null;
     }
-    return mill.ExtMove(move, side: side);
+    return mill.ExtMove(
+      move,
+      side: side,
+      boardLayout: event.payload['boardLayout'] as String?,
+    );
   }
 
   static mill.PieceColor? _pieceColorFromMover(String? mover) {

--- a/src/ui/flutter_app/lib/games/mill/mill_session_recorder_bridge.dart
+++ b/src/ui/flutter_app/lib/games/mill/mill_session_recorder_bridge.dart
@@ -17,16 +17,25 @@ import 'mill_constants.dart';
 class MillSessionRecorderBridge {
   MillSessionRecorderBridge({
     required GameSession session,
-    required mill.GameRecorder recorder,
-  }) : _recorder = recorder {
+    mill.GameRecorder? recorder,
+    mill.GameRecorder Function()? recorderProvider,
+  }) : assert(
+         recorder == null || recorderProvider == null,
+         'Provide either recorder or recorderProvider, not both.',
+       ),
+       _recorderProvider =
+           recorderProvider ??
+           (() => recorder ?? mill.GameController().gameRecorder) {
     _subscription = session.events.listen(_onEvent);
   }
 
   MillSessionRecorderBridge.forGameController({required GameSession session})
-    : this(session: session, recorder: mill.GameController().gameRecorder);
+    : this(session: session);
 
-  final mill.GameRecorder _recorder;
+  final mill.GameRecorder Function() _recorderProvider;
   late final StreamSubscription<GameSessionEvent> _subscription;
+
+  mill.GameRecorder get _recorder => _recorderProvider();
 
   Future<void> dispose() => _subscription.cancel();
 

--- a/src/ui/flutter_app/lib/games/mill/native_mill_game_session.dart
+++ b/src/ui/flutter_app/lib/games/mill/native_mill_game_session.dart
@@ -198,10 +198,12 @@ class NativeMillGameSession implements GameSessionHandle {
     }
     final PlayerSeat mover = _state.value.activeSeat;
     final GameStateSnapshot next = rulesPort.apply(action);
+    final String? boardLayout = _extractBoardLayout(rulesPort.exportFen());
     _setState(next);
     _emit(MillEventTypes.moveApplied, <String, Object?>{
       'type': action.type,
       'mover': mover.name,
+      if (boardLayout != null) 'boardLayout': boardLayout,
       ...action.payload,
     });
   }
@@ -368,6 +370,18 @@ class NativeMillGameSession implements GameSessionHandle {
     if (!_events.isClosed) {
       _events.add(GameSessionEvent(type, payload: payload));
     }
+  }
+
+  static String? _extractBoardLayout(String fen) {
+    final int spaceIdx = fen.indexOf(' ');
+    if (spaceIdx <= 0) {
+      return null;
+    }
+    final String boardLayout = fen.substring(0, spaceIdx);
+    if (boardLayout.length != 26) {
+      return null;
+    }
+    return boardLayout;
   }
 
   GameAction? _legalActionForBestMoveToNode(int toNode) {

--- a/src/ui/flutter_app/linux/my_application.cc
+++ b/src/ui/flutter_app/linux/my_application.cc
@@ -21,12 +21,7 @@
 #include <gdk/gdkx.h>
 #endif
 
-#include <iostream>
-#include <memory>
-
 #include "flutter/generated_plugin_registrant.h"
-
-#include "mill_engine.h"
 
 struct _MyApplication
 {
@@ -35,43 +30,6 @@ struct _MyApplication
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
-
-MillEngine *engine = nullptr;
-
-static void method_call_cb(FlMethodChannel *channel, FlMethodCall *method_call,
-                           gpointer user_data)
-{
-    const gchar *method = fl_method_call_get_name(method_call);
-
-    if (g_strcmp0(method, "startup") == 0) {
-        FlValue* value = fl_value_new_int(engine->startup());
-        fl_method_call_respond_success(method_call, value, nullptr);
-    } else if (g_strcmp0(method, "send") == 0) {
-        FlValue* args = fl_method_call_get_args(method_call);
-        const char* str = fl_value_get_string(args);
-        FlValue* value = fl_value_new_int(engine->send(str));
-        fl_method_call_respond_success(method_call, value, nullptr);
-    } else if (g_strcmp0(method, "read") == 0) {
-        FlValue* value = fl_value_new_string(engine->read().c_str());
-        fl_method_call_respond_success(method_call, value, nullptr);
-    } else if (g_strcmp0(method, "shutdown") == 0) {
-        FlValue* value = fl_value_new_int(engine->shutdown());
-        fl_method_call_respond_success(method_call, value, nullptr);
-    } else if (g_strcmp0(method, "isReady") == 0) {
-        FlValue* value = fl_value_new_bool(engine->isReady());
-        fl_method_call_respond_success(method_call, value, nullptr);
-    } else if (g_strcmp0(method, "isThinking") == 0) {
-        FlValue* value = fl_value_new_bool(engine->isThinking());
-        fl_method_call_respond_success(method_call, value, nullptr);
-    } else if (g_strcmp0(method, "getResponseDroppedCount") == 0) {
-        FlValue* value = fl_value_new_int(engine->getResponseDroppedCount());
-        fl_method_call_respond_success(method_call, value, nullptr);
-    } else {
-        g_autoptr(FlMethodResponse) response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
-        g_autoptr(GError) error = nullptr;
-        fl_method_call_respond(method_call, response, &error);
-    }
-}
 
 // Implements GApplication::activate.
 static void my_application_activate(GApplication *application)
@@ -121,24 +79,6 @@ static void my_application_activate(GApplication *application)
 
     fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
-    // START OF OUR CUSTOM  BLOCK
-
-    if (engine == nullptr) {
-        engine = new MillEngine();
-
-        // Get engine from view
-        FlEngine *fl_engine = fl_view_get_engine(view);
-
-        g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-        g_autoptr(FlBinaryMessenger) messenger = fl_engine_get_binary_messenger(fl_engine);
-        g_autoptr(FlMethodChannel) channel = fl_method_channel_new(messenger,
-                                        "com.calcitem.sanmill/engine",
-                                        FL_METHOD_CODEC(codec));
-        fl_method_channel_set_method_call_handler(channel, method_call_cb, g_object_ref(view), g_object_unref);
-    }
-
-    // END OF OUR CUSTOM BLOCK
-
     gtk_widget_grab_focus(GTK_WIDGET(view));
 }
 
@@ -167,12 +107,6 @@ static gboolean my_application_local_command_line(GApplication *application,
 // Implements GObject::dispose.
 static void my_application_dispose(GObject *object)
 {
-    if (engine != nullptr) {
-        engine->shutdown();
-        delete engine;
-        engine = nullptr;
-    }
-
     MyApplication *self = MY_APPLICATION(object);
     g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
     G_OBJECT_CLASS(my_application_parent_class)->dispose(object);

--- a/src/ui/flutter_app/test/game/mini_board_test.dart
+++ b/src/ui/flutter_app/test/game/mini_board_test.dart
@@ -5,6 +5,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sanmill/game_page/services/mill.dart' show PieceColor;
 import 'package:sanmill/game_page/widgets/mini_board.dart';
 import 'package:sanmill/shared/database/database.dart';
 
@@ -43,5 +44,14 @@ void main() {
     expect(tester.getSize(boardPainter), const Size(120, 120));
 
     await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  test('MiniBoardPainter parses a three-ring board layout', () {
+    final MiniBoardPainter painter = MiniBoardPainter(
+      boardLayout: 'O*******/********/*******@',
+    );
+
+    expect(painter.boardState[0], PieceColor.white);
+    expect(painter.boardState[23], PieceColor.black);
   });
 }

--- a/src/ui/flutter_app/test/games/mill/mill_session_recorder_bridge_test.dart
+++ b/src/ui/flutter_app/test/games/mill/mill_session_recorder_bridge_test.dart
@@ -175,6 +175,43 @@ void main() {
         'g7',
       ]);
     });
+
+    test(
+      'forGameController follows the current recorder after reset',
+      () async {
+        final _EventOnlySession session = _EventOnlySession();
+        final mill.GameController controller = mill.GameController();
+        controller.reset(force: true);
+
+        final MillSessionRecorderBridge bridge =
+            MillSessionRecorderBridge.forGameController(session: session);
+        addTearDown(bridge.dispose);
+
+        final mill.GameRecorder originalRecorder = controller.gameRecorder;
+
+        controller.reset(force: true);
+        final mill.GameRecorder currentRecorder = controller.gameRecorder;
+
+        expect(identical(originalRecorder, currentRecorder), isFalse);
+
+        session.emit(
+          const GameSessionEvent(
+            MillEventTypes.moveApplied,
+            payload: <String, Object?>{
+              'type': MillActionTypes.place,
+              'move': 'a7',
+              'mover': 'first',
+              'boardLayout': '********/********/*******O',
+            },
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(originalRecorder.mainlineMoves, isEmpty);
+        expect(currentRecorder.mainlineMoves, hasLength(1));
+        expect(currentRecorder.mainlineMoves.single.move, 'a7');
+      },
+    );
   });
 }
 

--- a/src/ui/flutter_app/test/games/mill/mill_session_recorder_bridge_test.dart
+++ b/src/ui/flutter_app/test/games/mill/mill_session_recorder_bridge_test.dart
@@ -34,6 +34,7 @@ void main() {
           'type': MillActionTypes.place,
           'move': 'a7',
           'mover': 'first',
+          'boardLayout': '********/********/*******O',
         },
       );
 
@@ -44,6 +45,7 @@ void main() {
       expect(move, isNotNull);
       expect(move!.move, 'a7');
       expect(move.side, mill.PieceColor.white);
+      expect(move.boardLayout, '********/********/*******O');
     });
 
     test('ignores non-move events and incomplete payloads', () {
@@ -80,6 +82,7 @@ void main() {
             'type': MillActionTypes.place,
             'move': 'a7',
             'mover': 'first',
+            'boardLayout': '********/********/*******O',
           },
         ),
       );
@@ -88,6 +91,10 @@ void main() {
       expect(recorder.mainlineMoves, hasLength(1));
       expect(recorder.mainlineMoves.single.move, 'a7');
       expect(recorder.mainlineMoves.single.side, mill.PieceColor.white);
+      expect(
+        recorder.mainlineMoves.single.boardLayout,
+        '********/********/*******O',
+      );
 
       // Replaying the same event should follow the existing node rather than
       // creating a duplicate move.

--- a/src/ui/flutter_app/test/games/mill/native_mill_game_session_test.dart
+++ b/src/ui/flutter_app/test/games/mill/native_mill_game_session_test.dart
@@ -43,6 +43,7 @@ void main() {
       );
       expect(events.last.payload['mover'], PlayerSeat.first.name);
       expect(events.last.payload['move'], 'a7');
+      expect(events.last.payload['boardLayout'], 'O*******/********/********');
     });
 
     test('rejects illegal actions without mutating state', () async {
@@ -259,5 +260,5 @@ class _FakeNativeMillRulesPort implements NativeMillRulesPort {
 
   @override
   String exportFen() =>
-      '********/********/******** w p p 0 9 0 9 0 0 0 0 0 0 0 0 1';
+      'O*******/********/******** w p p 0 9 0 9 0 0 0 0 0 0 0 0 1';
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## :scroll: Description
Restore Mill move history rendering on `next`, fix the Linux desktop launcher regression introduced by stale legacy engine glue, and update Cursor cloud environment config for Flutter Linux desktop prerequisites.

## :bulb: Motivation and Context
Two `next` regressions were fixed:
1. Linux desktop launch failed because `src/ui/flutter_app/linux/my_application.cc` still referenced the deleted legacy `mill_engine.h` bridge even though the Linux CMake target had already been migrated away from the old C++ engine wiring.
2. After moves were played, tapping `Move` opened the Move list page but showed only the empty-state actions because the native-session recorder bridge could keep writing into an old `GameRecorder` instance after `GameController.reset()` recreated the recorder.

## :green_heart: How did you test it?
- Ran `./format.sh s` from the repository root (Dart formatting succeeded; Rust clippy still reports existing unrelated warnings in `crates/tgf-search/benches/searcher.rs` and current worktree changes under `crates/tgf-frb/src/api/simple.rs`)
- Ran `flutter test test/games/mill/native_mill_game_session_test.dart`
- Ran `flutter test test/games/mill/mill_session_recorder_bridge_test.dart`
- Ran `flutter test test/game/mini_board_test.dart`
- Manually verified on Linux desktop after fixing local environment prerequisites:
  - Linux app now builds successfully (`✓ Built build/linux/x64/debug/bundle/mill`)
  - Main board UI renders on visible display
  - After several moves, tapping `Move` opens a populated Move list instead of the empty-state page
  - Miniboard previews render correctly with visible pieces/state
- Demo artifact: [move_list_and_miniboard_fixed_linux.mp4](https://cursor.com/agents/bc-a281e590-6f40-4f05-931a-f36bae7f3a0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmove_list_and_miniboard_fixed_linux.mp4)
- Supporting screenshots:
  - [Move list with working miniboard previews](https://cursor.com/agents/bc-a281e590-6f40-4f05-931a-f36bae7f3a0f/artifacts?path=%2Ftmp%2Fcomputer-use%2F980fe.webp)
  - [Additional move entries with working miniboards](https://cursor.com/agents/bc-a281e590-6f40-4f05-931a-f36bae7f3a0f/artifacts?path=%2Ftmp%2Fcomputer-use%2Ffe727.webp)

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
- Resolve the unrelated existing Rust warning failures in `crates/tgf-search/benches/searcher.rs` and the already-dirty FRB generated/worktree files if a fully clean `./format.sh s` is required.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a281e590-6f40-4f05-931a-f36bae7f3a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a281e590-6f40-4f05-931a-f36bae7f3a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

